### PR TITLE
M12-06: read a_ch by upstream's rule, and enforce JOIN on a join

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -70,12 +70,34 @@ All additive or strictly-safer; none affect unmodified device SDKs.
      unverifiable token — is a uniform `401` with no existence oracle;
      authorization refusals are `error` reply frames after the upgrade, not
      HTTP status codes.
-   - **The WATCH authorization paths are reconstructed from upstream
-     documentation, not from upstream source**: `groups/<name>` for a group
+   - **The `a_ch` grammar is measured, and it is not the REST grammar.**
+     Recorded against upstream v1.2.0 in
+     `test/conformance/upstream/channels.json`. Upstream partitions the `a_ch`
+     list by an **exact** match on the verb field, keeping only entries whose
+     first field is literally `JOIN` or `WATCH` and discarding every other
+     entry; the path regex is then matched within the chosen bucket. So the
+     astartectl-style blanket `.*::.*`, which authorizes every REST surface,
+     authorizes **nothing** on Channels — `.*` is not the string `JOIN`. A join
+     is checked against the room name with `rooms:<realm>:` stripped off, and
+     `Token.AuthorizesChannel` implements this separately from `Authorizes`,
+     which stays a verb-regex match because that is what upstream's REST plug
+     does. Astrate previously read `a_ch` with the REST rule and did not check
+     `JOIN` on a join at all; both were corrected in M12 phase 06.
+   - **The WATCH authorization paths are still a reading, and one is known to
+     be narrower than upstream's**: Astrate builds `groups/<name>` for a group
      trigger, `<device_id>/<interface>` for a data trigger, and `<device_id>`
-     otherwise, each checked as `Authorizes(a_ch, "WATCH", …)`. astartectl-style
-     `.*::.*` grants behave identically under any reading; narrowly-scoped
-     `a_ch` claims are where a divergence would show.
+     otherwise. Upstream's source builds `<device_id>/<interface><path>` and
+     `groups/<name>/<interface><path>` — it appends the trigger's match path,
+     which Astrate omits. The recording could not discriminate this, because
+     every recorded watch used `WATCH::.*`; it is therefore **not yet
+     measured**, and deliberately left alone rather than changed on a reading,
+     which is the mistake this milestone exists to undo.
+   - **A device trigger's `device_id` must sit inside `simple_trigger`.**
+     Upstream refuses a watch whose `device_id` is only at the payload's top
+     level — where the AppEngine REST API puts it — and refuses a wildcard
+     `device_id: "*"`, both with the misleading reason `unauthorized`. Astrate
+     falls back to the top-level `device_id` and accepts both. Recorded, not
+     yet reconciled.
    - **Transient triggers are matcher-only.** A `watch` payload's
      `simple_trigger` is compiled to a matcher with no action, never stored and
      never handed to the trigger executor. A slow viewer drops frames rather

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -639,6 +639,12 @@ Astarte's claim model is reproduced exactly so existing tokens/tooling (`astarte
   base* (e.g. `devices/h4-Dx_RYTU-RbpDOTabhRg/interfaces/...`).
 - Regexes are compiled once per token (LRU cache keyed by token hash) and are implicitly
   anchored as upstream does; `exp` honoured if present; `iat` not required (parity).
+- **`a_ch` is the exception and does not follow the rule above.** Upstream's Channels socket
+  matches the verb field *literally* against `JOIN` or `WATCH` and discards every entry that
+  is neither, so the catch-all `".*::.*"` authorizes nothing there. `Token.AuthorizesChannel`
+  implements that rule; `Token.Authorizes` keeps the verb-regex behaviour for the REST
+  surfaces. Measured, not inferred — see `test/conformance/upstream/channels.json` and
+  COMPATIBILITY.md deviation 1.
 - Multiple realm public keys allow zero-downtime key rotation (`PUT
   /realmmanagement/v1/<realm>/config/auth` parity endpoint).
 

--- a/internal/appengine/channels/ws.go
+++ b/internal/appengine/channels/ws.go
@@ -205,6 +205,12 @@ func (s *session) handleJoin(f Frame) {
 		s.sendErr(f, "unauthorized")
 		return
 	}
+	// Upstream authorizes every join, including a rejoin, against the room
+	// name with the realm stripped off.
+	if !s.tok.AuthorizesChannel(auth.VerbJoin, name) {
+		s.sendErr(f, "unauthorized")
+		return
+	}
 
 	s.roomsMu.Lock()
 	if j, ok := s.rooms[f.Topic]; ok {
@@ -263,7 +269,7 @@ func (s *session) handleWatch(f Frame) {
 		s.sendErr(f, "invalid simple_trigger")
 		return
 	}
-	if !s.tok.Authorizes(auth.ClaimChannels, "WATCH", path) {
+	if !s.tok.AuthorizesChannel(auth.VerbWatch, path) {
 		s.sendErr(f, "unauthorized")
 		return
 	}

--- a/internal/appengine/channels/ws_test.go
+++ b/internal/appengine/channels/ws_test.go
@@ -68,7 +68,7 @@ func TestPreUpgrade_MissingToken(t *testing.T) {
 
 func TestPreUpgrade_MissingRealm(t *testing.T) {
 	api, key := setupTestAPI(t)
-	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{".*::.*"}})
+	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{"JOIN::.*", "WATCH::.*"}})
 	mux := http.NewServeMux()
 	api.Mount(mux)
 	rec := httptest.NewRecorder()
@@ -81,7 +81,7 @@ func TestPreUpgrade_MissingRealm(t *testing.T) {
 
 func TestPreUpgrade_UnknownRealm(t *testing.T) {
 	api, key := setupTestAPI(t)
-	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{".*::.*"}})
+	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{"JOIN::.*", "WATCH::.*"}})
 	mux := http.NewServeMux()
 	api.Mount(mux)
 	rec := httptest.NewRecorder()
@@ -106,7 +106,7 @@ func TestPreUpgrade_InvalidToken(t *testing.T) {
 
 func TestPreUpgrade_HappyPath(t *testing.T) {
 	api, key := setupTestAPI(t)
-	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{".*::.*"}})
+	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{"JOIN::.*", "WATCH::.*"}})
 	mux := http.NewServeMux()
 	api.Mount(mux)
 	rec := httptest.NewRecorder()
@@ -135,7 +135,7 @@ func dialSession(t *testing.T, mux *http.ServeMux, token string) (*websocket.Con
 
 func TestWireSession_Heartbeat(t *testing.T) {
 	api, key := setupTestAPI(t)
-	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{".*::.*"}})
+	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{"JOIN::.*", "WATCH::.*"}})
 	mux := http.NewServeMux()
 	api.Mount(mux)
 	conn, cancel := dialSession(t, mux, token)
@@ -188,7 +188,7 @@ func TestWireSession_Heartbeat(t *testing.T) {
 
 func TestWireSession_JoinOwnRealm(t *testing.T) {
 	api, key := setupTestAPI(t)
-	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{".*::.*"}})
+	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{"JOIN::.*", "WATCH::.*"}})
 	mux := http.NewServeMux()
 	api.Mount(mux)
 	conn, cancel := dialSession(t, mux, token)
@@ -228,7 +228,7 @@ func TestWireSession_JoinOwnRealm(t *testing.T) {
 
 func TestWireSession_JoinRejected(t *testing.T) {
 	api, key := setupTestAPI(t)
-	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{".*::.*"}})
+	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{"JOIN::.*", "WATCH::.*"}})
 	mux := http.NewServeMux()
 	api.Mount(mux)
 	conn, cancel := dialSession(t, mux, token)
@@ -284,7 +284,7 @@ func TestWireSession_JoinRejected(t *testing.T) {
 
 func TestWireSession_Leave(t *testing.T) {
 	api, key := setupTestAPI(t)
-	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{".*::.*"}})
+	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{"JOIN::.*", "WATCH::.*"}})
 	mux := http.NewServeMux()
 	api.Mount(mux)
 	conn, cancel := dialSession(t, mux, token)
@@ -333,7 +333,7 @@ func TestWireSession_Leave(t *testing.T) {
 
 func TestWireSession_LeaveWithoutJoin(t *testing.T) {
 	api, key := setupTestAPI(t)
-	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{".*::.*"}})
+	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{"JOIN::.*", "WATCH::.*"}})
 	mux := http.NewServeMux()
 	api.Mount(mux)
 	conn, cancel := dialSession(t, mux, token)
@@ -404,7 +404,7 @@ func readFramePayloadStatus(t *testing.T, conn *websocket.Conn) string {
 
 func TestWireSession_Watch_Accepted(t *testing.T) {
 	api, key, _ := setupTestAPIWithBus(t)
-	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{".*::.*"}})
+	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{"JOIN::.*", "WATCH::.*"}})
 	mux := http.NewServeMux()
 	api.Mount(mux)
 	conn, cancel := dialSession(t, mux, token)
@@ -437,8 +437,8 @@ func TestWireSession_Watch_Accepted(t *testing.T) {
 
 func TestWireSession_Watch_Rejected(t *testing.T) {
 	api, key, _ := setupTestAPIWithBus(t)
-	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{".*::.*"}})
-	restrictiveToken := mintToken(t, key, jwt.MapClaims{"a_ch": []string{"WATCH::" + validDeviceIDA}})
+	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{"JOIN::.*", "WATCH::.*"}})
+	restrictiveToken := mintToken(t, key, jwt.MapClaims{"a_ch": []string{"JOIN::.*", "WATCH::" + validDeviceIDA}})
 	mux := http.NewServeMux()
 	api.Mount(mux)
 
@@ -540,7 +540,7 @@ func TestWireSession_Watch_Rejected(t *testing.T) {
 
 func TestWireSession_NewEvent(t *testing.T) {
 	api, key, bus := setupTestAPIWithBus(t)
-	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{".*::.*"}})
+	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{"JOIN::.*", "WATCH::.*"}})
 	mux := http.NewServeMux()
 	api.Mount(mux)
 	conn, cancel := dialSession(t, mux, token)
@@ -632,7 +632,7 @@ func TestWireSession_NewEvent(t *testing.T) {
 // the race detector and not panicking; frame contents are covered elsewhere.
 func TestWireSession_PumpRacesLeave(t *testing.T) {
 	api, key, bus := setupTestAPIWithBus(t)
-	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{".*::.*"}})
+	token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{"JOIN::.*", "WATCH::.*"}})
 	mux := http.NewServeMux()
 	api.Mount(mux)
 	conn, cancel := dialSession(t, mux, token)
@@ -689,4 +689,91 @@ func TestWireSession_PumpRacesLeave(t *testing.T) {
 		t.Fatalf("write leave: %v", err)
 	}
 	<-fed
+}
+
+// TestWireSession_JoinAuthorization drives the a_ch grammar over the real wire,
+// with the rows recorded from upstream in test/conformance/upstream/channels.json.
+// The unit table in internal/auth proves the matcher; this proves the socket
+// actually consults it on a join, which it did not before M12 phase 06.
+//
+// The refusals are paired with acceptances on the same room, so a socket that
+// refused every join could not pass.
+func TestWireSession_JoinAuthorization(t *testing.T) {
+	const room = "dashboard_1"
+
+	cases := []struct {
+		name    string
+		grants  []string
+		wantOK  bool
+		because string
+	}{
+		{"blanket .*::.*", []string{".*::.*"}, false,
+			`".*" is not the literal verb "JOIN"; upstream refuses this join`},
+		{"blanket .*", []string{".*"}, false,
+			"an entry without the three-field form is discarded"},
+		{"JOIN::.*", []string{"JOIN::.*"}, true,
+			"the paired acceptance for the two refusals above"},
+		{"JOIN::<this room>", []string{"JOIN::" + room}, true,
+			"an exact-room grant is honoured"},
+		{"JOIN::<other room>", []string{"JOIN::other"}, false,
+			"same verb, wrong room — the room name is really matched"},
+		{"WATCH only", []string{"WATCH::.*"}, false,
+			"a watch grant is a separate bucket and does not admit a join"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			api, key := setupTestAPI(t)
+			token := mintToken(t, key, jwt.MapClaims{"a_ch": tc.grants})
+			mux := http.NewServeMux()
+			api.Mount(mux)
+			conn, cancel := dialSession(t, mux, token)
+			defer cancel()
+			defer conn.CloseNow()
+
+			ctx := context.Background()
+			topic := "rooms:" + testRealmName + ":" + room
+			if err := conn.Write(ctx, websocket.MessageText,
+				[]byte(`["1","1","`+topic+`","phx_join",{}]`)); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+
+			_, raw, err := conn.Read(ctx)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			var f Frame
+			if err := json.Unmarshal(raw, &f); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			var payload struct {
+				Status   string `json:"status"`
+				Response struct {
+					Reason string `json:"reason"`
+				} `json:"response"`
+			}
+			if err := json.Unmarshal(f.Payload, &payload); err != nil {
+				t.Fatalf("decode payload: %v", err)
+			}
+
+			if tc.wantOK {
+				if payload.Status != "ok" {
+					t.Errorf("status = %s, want ok (a_ch=%v: %s)", payload.Status, tc.grants, tc.because)
+				}
+				if api.reg.Rooms() != 1 {
+					t.Errorf("Rooms() = %d, want 1 — an authorized join must create the room", api.reg.Rooms())
+				}
+				return
+			}
+			if payload.Status != "error" {
+				t.Errorf("status = %s, want error (a_ch=%v: %s)", payload.Status, tc.grants, tc.because)
+			}
+			if payload.Response.Reason != "unauthorized" {
+				t.Errorf("reason = %q, want %q", payload.Response.Reason, "unauthorized")
+			}
+			if api.reg.Rooms() != 0 {
+				t.Errorf("Rooms() = %d, want 0 — a refused join must not create the room", api.reg.Rooms())
+			}
+		})
+	}
 }

--- a/internal/auth/claims.go
+++ b/internal/auth/claims.go
@@ -72,10 +72,13 @@ type astarteClaims struct {
 }
 
 // grant is one compiled authorization string: a verb regex and a path regex,
-// both implicitly anchored.
+// both implicitly anchored. verbLiteral is the verb field before compilation,
+// which the Channels surface matches by equality rather than as a regex — see
+// AuthorizesChannel.
 type grant struct {
-	verb *regexp.Regexp
-	path *regexp.Regexp
+	verb        *regexp.Regexp
+	verbLiteral string
+	path        *regexp.Regexp
 }
 
 // compileGrant compiles one authorization string with upstream parity
@@ -105,7 +108,7 @@ func compileGrant(s string) (grant, bool) {
 	if err != nil {
 		return grant{}, false
 	}
-	return grant{verb: verb, path: path}, true
+	return grant{verb: verb, verbLiteral: parts[0], path: path}, true
 }
 
 // Token is a verified JWT: its expiry and its compiled authorization grants.
@@ -156,6 +159,39 @@ func (t *Token) ExpiresAt() (time.Time, bool) {
 func (t *Token) Authorizes(claim Claim, verb, authPath string) bool {
 	for _, g := range t.grants[claim] {
 		if g.verb.MatchString(verb) && g.path.MatchString(authPath) {
+			return true
+		}
+	}
+	return false
+}
+
+// Channels authorization verbs. Upstream recognises exactly these two and
+// silently discards an a_ch entry carrying anything else.
+const (
+	VerbJoin  = "JOIN"
+	VerbWatch = "WATCH"
+)
+
+// AuthorizesChannel reports whether the a_ch claim grants verb (VerbJoin or
+// VerbWatch) on authPath — the room name for a join, the trigger's target for
+// a watch.
+//
+// It deliberately does not reuse Authorizes, because upstream reads a_ch by a
+// different rule than the REST claims and the difference is observable. The
+// REST plug compiles the verb field into a regex and matches it against the
+// HTTP method, so "GET|POST" works and ".*::.*" grants everything. The
+// Channels socket instead *partitions* the a_ch list by an exact match on the
+// verb field, keeping only entries whose first field is literally "JOIN" or
+// "WATCH" and discarding the rest, then matches the path regex within the
+// chosen bucket.
+//
+// So a blanket ".*::.*" — which authorizes every REST surface — authorizes
+// nothing here: ".*" is not the string "JOIN". This is measured, not inferred;
+// see test/conformance/upstream/channels.json, where upstream refuses a join
+// under ".*::.*" and accepts the same join under "JOIN::.*".
+func (t *Token) AuthorizesChannel(verb, authPath string) bool {
+	for _, g := range t.grants[ClaimChannels] {
+		if g.verbLiteral == verb && g.path.MatchString(authPath) {
 			return true
 		}
 	}

--- a/internal/auth/claims_test.go
+++ b/internal/auth/claims_test.go
@@ -128,3 +128,103 @@ func TestStringListLenientDecoding(t *testing.T) {
 		t.Error("numeric claim should fail to decode")
 	}
 }
+
+// TestAuthorizesChannelParity is the a_ch table recorded from upstream Astarte
+// v1.2.0 in test/conformance/upstream/channels.json. Channels reads a_ch by a
+// different rule than the REST claims: the verb field is matched by equality,
+// not compiled as a regex, so the blanket grant that authorizes every REST
+// surface authorizes nothing here.
+//
+// Each refusal is paired with an acceptance that differs only in the rule under
+// test, so a matcher that refused everything could not pass the table.
+func TestAuthorizesChannelParity(t *testing.T) {
+	const room = "probe"
+
+	cases := []struct {
+		name   string
+		grants []string // a_ch authorization strings
+		verb   string
+		path   string
+		want   bool
+		rule   string
+	}{
+		{
+			name: "blanket .*::.* authorizes no join", grants: []string{".*::.*"},
+			verb: VerbJoin, path: room, want: false,
+			rule: `".*" is not the literal string "JOIN"`,
+		},
+		{
+			name: "blanket .* authorizes no join", grants: []string{".*"},
+			verb: VerbJoin, path: room, want: false,
+			rule: "an entry without the three-field form is discarded",
+		},
+		{
+			name: "JOIN::.* authorizes the join", grants: []string{"JOIN::.*"},
+			verb: VerbJoin, path: room, want: true,
+			rule: "the paired acceptance: an explicit JOIN verb is what upstream requires",
+		},
+		{
+			name: "JOIN::<this room> authorizes the join", grants: []string{"JOIN::probe"},
+			verb: VerbJoin, path: room, want: true,
+			rule: "an exact-room grant is honoured",
+		},
+		{
+			name: "JOIN::<other room> does not", grants: []string{"JOIN::other"},
+			verb: VerbJoin, path: room, want: false,
+			rule: "the room name is really matched, not merely the verb",
+		},
+		{
+			name: "WATCH::.* authorizes a watch", grants: []string{"JOIN::.*", "WATCH::.*"},
+			verb: VerbWatch, path: "device/iface", want: true,
+			rule: "the watch bucket is selected by its own verb",
+		},
+		{
+			name: "a JOIN grant does not authorize a watch", grants: []string{"JOIN::.*"},
+			verb: VerbWatch, path: "device/iface", want: false,
+			rule: "the two verbs are separate buckets, not a shared path list",
+		},
+		{
+			name: "a WATCH grant does not authorize a join", grants: []string{"WATCH::.*"},
+			verb: VerbJoin, path: room, want: false,
+			rule: "the two verbs are separate buckets, not a shared path list",
+		},
+		{
+			name: "an unknown verb is discarded", grants: []string{"SUBSCRIBE::.*"},
+			verb: VerbJoin, path: room, want: false,
+			rule: "upstream keeps only JOIN and WATCH entries",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.grants)
+			if err != nil {
+				t.Fatalf("marshalling grants: %v", err)
+			}
+			tok := tokenWithClaims(t, `{"a_ch": `+string(b)+`}`)
+			if got := tok.AuthorizesChannel(tc.verb, tc.path); got != tc.want {
+				t.Errorf("AuthorizesChannel(%q, %q) with a_ch=%v = %v, want %v — %s",
+					tc.verb, tc.path, tc.grants, got, tc.want, tc.rule)
+			}
+		})
+	}
+}
+
+// TestRESTVerbStaysARegex is the invariant the change above must not break.
+// Upstream's REST plug compiles the verb field into a regex and matches it
+// against the HTTP method, so ".*::.*" grants every REST surface and "GET|POST"
+// selects two methods. Only Channels departs from this.
+func TestRESTVerbStaysARegex(t *testing.T) {
+	tok := tokenWithClaims(t, `{"a_aea": [".*::.*"]}`)
+	if !tok.Authorizes(ClaimAppEngine, "GET", "devices") {
+		t.Error(`".*::.*" must still authorize a REST GET — the verb field is a regex there`)
+	}
+	if tok.AuthorizesChannel(VerbJoin, "devices") {
+		t.Error("an a_aea grant must not authorize the Channels surface at all")
+	}
+
+	alt := tokenWithClaims(t, `{"a_aea": ["GET|POST::devices"]}`)
+	if !alt.Authorizes(ClaimAppEngine, "POST", "devices") {
+		t.Error(`"GET|POST" must still match POST — the verb field is a regex there`)
+	}
+}


### PR DESCRIPTION
Makes Astrate agree with the `a_ch` grammar recorded in `test/conformance/upstream/channels.json`, and confirmed against upstream v1.2.0's source.

## The rule

Upstream reads `a_ch` differently from the REST claims:

| surface | verb field | blanket `.*::.*` |
| --- | --- | --- |
| REST (`a_aea`, `a_pa`, …) | compiled as a **regex**, matched against the HTTP method | grants everything |
| Channels (`a_ch`) | matched **literally** against `JOIN` / `WATCH`; other entries discarded | grants **nothing** |

`.*` is not the string `JOIN`. M11 assumed the permissive reading — which is why the entire wire-session test file was built on `.*::.*`, a claim upstream refuses.

## What changed

- `Token.AuthorizesChannel` implements the Channels rule. `Token.Authorizes` is untouched and keeps the verb-regex behaviour, because that is what upstream's REST plug does.
- **`handleJoin` never checked `JOIN` at all** — any token bearing `a_ch` could join any room in its realm. It now does, on every join including a rejoin, against the room name with `rooms:<realm>:` stripped.
- The wire-session tests are re-minted with `JOIN::.*`/`WATCH::.*`.

## Verification

`go test -race ./...` green, lint clean, gofmt clean. Both rules mutation-checked on a verified-clean baseline:

| mutation | red |
| --- | --- |
| verb matched as a regex again (the M11 reading) | `TestAuthorizesChannelParity/blanket_.*::.*`, `TestWireSession_JoinAuthorization/blanket_.*::.*` |
| join check removed | 4 rows of `TestWireSession_JoinAuthorization` |

Every refusal row is paired with an acceptance differing only in the rule under test, so a matcher that refused everything could not pass the table. `TestRESTVerbStaysARegex` pins the invariant that REST parity does not regress.

## Recorded but deliberately not changed

Both are documented in `COMPATIBILITY.md` as unreconciled rather than fixed on a reading — every recorded watch used `WATCH::.*`, so the recording cannot discriminate them:

- Astrate's watch path omits the trigger's match path (upstream builds `<device_id>/<interface><path>`).
- Upstream refuses a device trigger whose `device_id` is only at the payload top level, and refuses `device_id: "*"`; Astrate accepts both.