### PR TITLE
M12-06b: measure what a WATCH claim is matched against, and agree with it

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -83,21 +83,24 @@ All additive or strictly-safer; none affect unmodified device SDKs.
      which stays a verb-regex match because that is what upstream's REST plug
      does. Astrate previously read `a_ch` with the REST rule and did not check
      `JOIN` on a join at all; both were corrected in M12 phase 06.
-   - **The WATCH authorization paths are still a reading, and one is known to
-     be narrower than upstream's**: Astrate builds `groups/<name>` for a group
-     trigger, `<device_id>/<interface>` for a data trigger, and `<device_id>`
-     otherwise. Upstream's source builds `<device_id>/<interface><path>` and
-     `groups/<name>/<interface><path>` — it appends the trigger's match path,
-     which Astrate omits. The recording could not discriminate this, because
-     every recorded watch used `WATCH::.*`; it is therefore **not yet
-     measured**, and deliberately left alone rather than changed on a reading,
-     which is the mistake this milestone exists to undo.
-   - **A device trigger's `device_id` must sit inside `simple_trigger`.**
-     Upstream refuses a watch whose `device_id` is only at the payload's top
-     level — where the AppEngine REST API puts it — and refuses a wildcard
-     `device_id: "*"`, both with the misleading reason `unauthorized`. Astrate
-     falls back to the top-level `device_id` and accepts both. Recorded, not
-     yet reconciled.
+   - **The WATCH authorization paths are measured**, with narrow claims that
+     make exactly one of each pair acceptable
+     (`test/conformance/upstream/channels.json`). A data trigger is authorized
+     against `<device_id>/<interface_name><match_path>` — the match path is
+     appended, carrying its own leading slash — and a device trigger against
+     the bare `<device_id>`. Astrate built `<device_id>/<interface_name>` for
+     data triggers until M12 phase 06b, which was wrong in *both* directions:
+     it refused claims upstream accepts and accepted claims upstream refuses.
+     The group shapes (`groups/<name>/<interface><match_path>` and
+     `groups/<name>`) come from the same upstream function but are **not
+     measured**, the realm having no group; they are the one part of this
+     surface still resting on a source read.
+   - **A device trigger's `device_id` must sit inside `simple_trigger` and
+     equal the request's own.** Upstream refuses a watch whose `device_id` is
+     only at the payload's top level — where the AppEngine REST API puts it —
+     and refuses a wildcard `device_id: "*"`, both with the misleading reason
+     `unauthorized`. Astrate used to fall back to the top-level `device_id` and
+     accept both; since M12 phase 06b it refuses them with the same reason.
    - **Transient triggers are matcher-only.** A `watch` payload's
      `simple_trigger` is compiled to a matcher with no action, never stored and
      never handed to the trigger executor. A slow viewer drops frames rather

--- a/internal/appengine/channels/ws.go
+++ b/internal/appengine/channels/ws.go
@@ -113,27 +113,55 @@ type joined struct {
 type triggerShape struct {
 	Type          string `json:"type"`
 	InterfaceName string `json:"interface_name"`
+	MatchPath     string `json:"match_path"`
 	GroupName     string `json:"group_name"`
 	DeviceID      string `json:"device_id"`
 }
 
-// watchAuthPath derives the authorization path from a WatchRequest.
+// errUnauthorizedTrigger is a device trigger that names no device, or names a
+// different one than the request. Upstream refuses these — see watchAuthPath.
+var errUnauthorizedTrigger = errors.New("device trigger does not name the request's device")
+
+// watchAuthPath derives the authorization path from a WatchRequest, in the
+// shape upstream matches a_ch WATCH claims against. The shapes are recorded in
+// test/conformance/upstream/channels.json:
+//
+//	data trigger        <device_id>/<interface_name><match_path>
+//	device trigger      <device_id>
+//	group data trigger  groups/<name>/<interface_name><match_path>
+//	group device trigger groups/<name>
+//
+// The match path carries its own leading slash, so it is concatenated without a
+// separator. That detail is measured, not inferred: a claim written as
+// "<device>/<interface>" — the shape Astrate used to build — is refused by
+// upstream for a trigger on /value, while "<device>/<interface>/value" is
+// accepted. Only the group shapes are unmeasured, the realm having no group;
+// they come from the same upstream function whose device shapes the recording
+// just confirmed.
+//
+// A device trigger must name its device inside simple_trigger, and it must be
+// the request's device: upstream refuses a device_id present only at the
+// payload's top level (where the AppEngine REST API puts it) and refuses the
+// wildcard "*", both with the reason "unauthorized". Astrate used to fall back
+// to the top-level device_id and accept both.
 func watchAuthPath(req WatchRequest) (string, error) {
 	var ts triggerShape
 	if err := json.Unmarshal(req.SimpleTrigger, &ts); err != nil {
 		return "", err
 	}
+	if ts.Type == "data_trigger" {
+		if ts.GroupName != "" {
+			return "groups/" + ts.GroupName + "/" + ts.InterfaceName + ts.MatchPath, nil
+		}
+		return req.DeviceID + "/" + ts.InterfaceName + ts.MatchPath, nil
+	}
 	if ts.GroupName != "" {
 		return "groups/" + ts.GroupName, nil
 	}
-	device := ts.DeviceID
-	if device == "" {
-		device = req.DeviceID
+	if ts.DeviceID == "" || ts.DeviceID != req.DeviceID {
+		return "", errUnauthorizedTrigger
 	}
-	if ts.Type == "data_trigger" {
-		return device + "/" + ts.InterfaceName, nil
-	}
-	return device, nil
+	return ts.DeviceID, nil
 }
 
 // loop reads frames from the connection and dispatches them.
@@ -265,6 +293,12 @@ func (s *session) handleWatch(f Frame) {
 	}
 
 	path, err := watchAuthPath(req)
+	if errors.Is(err, errUnauthorizedTrigger) {
+		// Upstream's reason for this is "unauthorized", not a payload error,
+		// even though the cause is the payload's shape.
+		s.sendErr(f, "unauthorized")
+		return
+	}
 	if err != nil {
 		s.sendErr(f, "invalid simple_trigger")
 		return

--- a/internal/appengine/channels/ws_test.go
+++ b/internal/appengine/channels/ws_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -773,6 +774,142 @@ func TestWireSession_JoinAuthorization(t *testing.T) {
 			}
 			if api.reg.Rooms() != 0 {
 				t.Errorf("Rooms() = %d, want 0 — a refused join must not create the room", api.reg.Rooms())
+			}
+		})
+	}
+}
+
+// TestWatchAuthPath pins the authorization-path shapes upstream matches a_ch
+// WATCH claims against, recorded in test/conformance/upstream/channels.json.
+//
+// The data-trigger row is the one the recording settled: a claim written as
+// "<device>/<interface>" — the shape Astrate built before M12 phase 06b — is
+// refused by upstream for a trigger on /value, while
+// "<device>/<interface>/value" is accepted.
+func TestWatchAuthPath(t *testing.T) {
+	const dev = validDeviceIDA
+
+	cases := []struct {
+		name    string
+		req     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "data trigger appends the match path",
+			req:  `{"device_id":"` + dev + `","simple_trigger":{"type":"data_trigger","interface_name":"org.example.V1","match_path":"/value"}}`,
+			want: dev + "/org.example.V1/value",
+		},
+		{
+			name: "data trigger with a nested match path",
+			req:  `{"device_id":"` + dev + `","simple_trigger":{"type":"data_trigger","interface_name":"org.example.V1","match_path":"/data/temp"}}`,
+			want: dev + "/org.example.V1/data/temp",
+		},
+		{
+			name: "device trigger is the bare device id",
+			req:  `{"device_id":"` + dev + `","simple_trigger":{"type":"device_trigger","on":"device_error","device_id":"` + dev + `"}}`,
+			want: dev,
+		},
+		{
+			name:    "device trigger without its own device_id is refused",
+			req:     `{"device_id":"` + dev + `","simple_trigger":{"type":"device_trigger","on":"device_error"}}`,
+			wantErr: true,
+		},
+		{
+			name:    "device trigger naming a different device is refused",
+			req:     `{"device_id":"` + dev + `","simple_trigger":{"type":"device_trigger","on":"device_error","device_id":"` + validDeviceIDB + `"}}`,
+			wantErr: true,
+		},
+		{
+			name:    `device trigger with the wildcard "*" is refused`,
+			req:     `{"device_id":"` + dev + `","simple_trigger":{"type":"device_trigger","on":"device_error","device_id":"*"}}`,
+			wantErr: true,
+		},
+		{
+			name: "group data trigger",
+			req:  `{"simple_trigger":{"type":"data_trigger","group_name":"g1","interface_name":"org.example.V1","match_path":"/value"}}`,
+			want: "groups/g1/org.example.V1/value",
+		},
+		{
+			name: "group device trigger",
+			req:  `{"simple_trigger":{"type":"device_trigger","group_name":"g1","on":"device_error"}}`,
+			want: "groups/g1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var req WatchRequest
+			if err := json.Unmarshal([]byte(tc.req), &req); err != nil {
+				t.Fatalf("decoding request: %v", err)
+			}
+			got, err := watchAuthPath(req)
+			if tc.wantErr {
+				if !errors.Is(err, errUnauthorizedTrigger) {
+					t.Errorf("watchAuthPath() error = %v, want errUnauthorizedTrigger (got path %q)", err, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("watchAuthPath() unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("watchAuthPath() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWireSession_WatchPathIsMatchPathScoped drives the settled data-trigger
+// rows over the real wire. The refusal and the acceptance differ only in the
+// claim, on an identical payload, so neither can be explained by the payload
+// being rejected for some other reason — which is exactly how the first attempt
+// at recording these rows went wrong upstream (a missing interface_major made
+// both claims look refused).
+func TestWireSession_WatchPathIsMatchPathScoped(t *testing.T) {
+	const iface = "org.example.V1"
+
+	cases := []struct {
+		name   string
+		claim  string
+		wantOK bool
+	}{
+		{"claim without the match path is refused", "WATCH::" + validDeviceIDA + "/" + iface, false},
+		{"claim with the match path is accepted", "WATCH::" + validDeviceIDA + "/" + iface + "/value", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			api, key, _ := setupTestAPIWithBus(t)
+			token := mintToken(t, key, jwt.MapClaims{"a_ch": []string{"JOIN::.*", tc.claim}})
+			mux := http.NewServeMux()
+			api.Mount(mux)
+			conn, cancel := dialSession(t, mux, token)
+			defer cancel()
+			defer conn.CloseNow()
+
+			ctx := context.Background()
+			topic := "rooms:" + testRealmName + ":dashboard_1"
+			joinTopic(t, conn, topic, "1")
+			if _, _, err := conn.Read(ctx); err != nil {
+				t.Fatalf("read join reply: %v", err)
+			}
+
+			payload := `{"name":"t","device_id":"` + validDeviceIDA +
+				`","simple_trigger":{"type":"data_trigger","on":"incoming_data","interface_name":"` +
+				iface + `","interface_major":1,"match_path":"/value","value_match_operator":"*"}}`
+			if err := conn.Write(ctx, websocket.MessageText,
+				[]byte(`["1","2","`+topic+`","watch",`+payload+`]`)); err != nil {
+				t.Fatalf("write watch: %v", err)
+			}
+
+			status := readFramePayloadStatus(t, conn)
+			want := "error"
+			if tc.wantOK {
+				want = "ok"
+			}
+			if status != want {
+				t.Errorf("watch status = %s, want %s (a_ch claim %q)", status, want, tc.claim)
 			}
 		})
 	}

--- a/test/conformance/upstream/README.md
+++ b/test/conformance/upstream/README.md
@@ -152,15 +152,60 @@ paired so a refusal cannot be explained by a server that refuses everything:
 | join a room | `JOIN::<another room>` | refused |
 | watch a data trigger | `WATCH::.*` | accepted |
 
-**A blanket grant is not a grant.** Upstream matches the claim against `JOIN::<room name>`, so
-`.*::.*` fails for want of a `::` the room name does not contain — the opposite of the permissive
-reading M11 assumed. The verb is also matched per room, not merely required to be present.
+**A blanket grant is not a grant**, and the reason is not the one first written here. Upstream
+*partitions* the `a_ch` list by an **exact** match on the verb field: an entry is split on `:` into
+three parts and kept only if its first field is literally `JOIN` or `WATCH`, everything else being
+discarded. The path regex is then matched within the chosen bucket. So `.*::.*` authorizes nothing
+because `.*` is not the string `JOIN` — not, as the first version of this note claimed, because the
+room name lacks a `::`. That earlier story is refuted by the `.*` row in the same table: under it,
+`.*` would have matched the bare room name and been accepted, and it was refused. Confirmed against
+upstream's source (`socket_guardian.ex`, `extract_authorization_paths/2`, pinned `^match_prefix`).
+
+### What the `WATCH` claim is matched against
+
+The rows above all used `WATCH::.*`, which accepts whatever string upstream builds and therefore
+cannot say what that string *is*. These use narrow claims, so exactly one of a pair can be accepted:
+
+| trigger | claim | |
+| --- | --- | --- |
+| data trigger on `/value` | `WATCH::<device>/<interface>` | refused |
+| data trigger on `/value` | `WATCH::<device>/<interface>/value` | accepted |
+| device trigger | `WATCH::<that device>` | accepted |
+| device trigger | `WATCH::<another device>` | refused |
+
+So a data trigger's authorization path is **`<device_id>/<interface_name><match_path>`** — the
+match path is appended, with no separator because it already begins with a slash — and a device
+trigger's is the **bare device id**. Astrate built `<device_id>/<interface_name>` for data triggers
+until M12 phase 06b, which is wrong in *both* directions: it refused claims upstream accepts and
+accepted claims upstream refuses.
+
+The group shapes (`groups/<name>/<interface><match_path>` and `groups/<name>`) come from the same
+upstream function and are **not measured** — the realm has no group. They are the one part of this
+section still resting on a source read.
 
 One more, which is a client-facing trap rather than an authorization rule: a `device_trigger` is
-authorized only when `device_id` sits **inside `simple_trigger`**. With `device_id` only at the
-payload's top level — where the AppEngine REST API puts it — upstream refuses with
-`reason: "unauthorized"`, which sends a client author to look at their token for what is really a
-payload-shape problem. A wildcard `device_id: "*"` is refused too, even under `WATCH::.*`.
+authorized only when `device_id` sits **inside `simple_trigger`** *and equals the request's own
+`device_id`*. With `device_id` only at the payload's top level — where the AppEngine REST API puts
+it — upstream refuses with `reason: "unauthorized"`, which sends a client author to look at their
+token for what is really a payload-shape problem. A wildcard `device_id: "*"` is refused too, even
+under `WATCH::.*`.
+
+**A trap that cost this recording a pass:** `interface_major` is required as soon as
+`interface_name` is not `"*"`, and omitting it is refused with
+`{"errors":{"simple_trigger":{"interface_major":["can't be blank"]}}}` — a *validation* error
+returned before authorization is consulted at all. To a recorder checking only for `"status":"ok"`
+that is a refusal like any other, so both narrow data-trigger rows first came back "refused" and
+would have been read as evidence about the authorization path. The recorder now prints a loud
+`!! VALIDATION ERROR, NOT AN AUTHORIZATION REFUSAL` on any reply carrying `"errors"` rather than
+`"reason"`.
+
+### Re-recording one section at a time
+
+`ASTARTE_UPSTREAM_SECTION=auth|errors|all` (default `all`) re-records one section and carries the
+other over from the committed fixture, refusing to write a fixture with a section empty. Delivery of
+`device_error` to the room is unreliable on this stack, so settling an authorization question with a
+full re-run would churn `attempts`/`delivered` counts that were measured carefully and are not what
+is being asked about.
 
 ### Two facts a re-recorder needs and will otherwise lose an evening to
 

--- a/test/conformance/upstream/channels.json
+++ b/test/conformance/upstream/channels.json
@@ -1,5 +1,5 @@
 {
-  "recorded_at": "2026-07-26T20:53:09Z",
+  "recorded_at": "2026-07-26T22:34:04Z",
   "astarte_version": "v1.2.0",
   "realm": "bench",
   "recorder_command": "go run ./recordchannels",
@@ -105,6 +105,54 @@
       ],
       "operation": "watch",
       "payload": "{\"device_id\":\"KqYJ16Cs7lyeJ3PPzg7xQg\",\"name\":\"probe\",\"simple_trigger\":{\"device_id\":\"*\",\"on\":\"device_error\",\"type\":\"device_trigger\"}}",
+      "reply": "[\"1\",\"2\",\"rooms:bench:probe\",\"phx_reply\",{\"status\":\"error\",\"response\":{\"reason\":\"unauthorized\"}}]",
+      "accepted": false
+    },
+    {
+      "name": "watch data_trigger, claim WATCH::\u003cdevice\u003e/\u003cinterface\u003e (Astrate's shape)",
+      "why": "Astrate authorizes a data trigger against `\u003cdevice_id\u003e/\u003cinterface\u003e`, with no match path. If upstream built the same string this is accepted; if upstream appends the match path it is refused, because the anchored claim regex cannot match the longer string.",
+      "a_ch_claims": [
+        "JOIN::.*",
+        "WATCH::KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Individual"
+      ],
+      "operation": "watch",
+      "payload": "{\"device_id\":\"KqYJ16Cs7lyeJ3PPzg7xQg\",\"name\":\"probe\",\"simple_trigger\":{\"interface_major\":1,\"interface_name\":\"org.astrate.bench.Individual\",\"match_path\":\"/value\",\"on\":\"incoming_data\",\"type\":\"data_trigger\",\"value_match_operator\":\"*\"}}",
+      "reply": "[\"1\",\"2\",\"rooms:bench:probe\",\"phx_reply\",{\"status\":\"error\",\"response\":{\"reason\":\"unauthorized\"}}]",
+      "accepted": false
+    },
+    {
+      "name": "watch data_trigger, claim WATCH::\u003cdevice\u003e/\u003cinterface\u003e\u003cmatch_path\u003e",
+      "why": "The paired alternative, and upstream's shape according to its source (`\"#{device_id}/#{interface_name}#{path}\"`, with no separator because the path already starts with a slash). Exactly one of this row and the one above can be accepted, so together they identify the authorization path rather than merely confirming a guess.",
+      "a_ch_claims": [
+        "JOIN::.*",
+        "WATCH::KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Individual/value"
+      ],
+      "operation": "watch",
+      "payload": "{\"device_id\":\"KqYJ16Cs7lyeJ3PPzg7xQg\",\"name\":\"probe\",\"simple_trigger\":{\"interface_major\":1,\"interface_name\":\"org.astrate.bench.Individual\",\"match_path\":\"/value\",\"on\":\"incoming_data\",\"type\":\"data_trigger\",\"value_match_operator\":\"*\"}}",
+      "reply": "[\"1\",\"2\",\"rooms:bench:probe\",\"phx_reply\",{\"status\":\"ok\",\"response\":{}}]",
+      "accepted": true
+    },
+    {
+      "name": "watch device_trigger, claim WATCH::\u003cthis device\u003e",
+      "why": "A device trigger's authorization path is claimed to be the bare device id. A narrow, exact claim accepts it, which is what identifies the path.",
+      "a_ch_claims": [
+        "JOIN::.*",
+        "WATCH::KqYJ16Cs7lyeJ3PPzg7xQg"
+      ],
+      "operation": "watch",
+      "payload": "{\"device_id\":\"KqYJ16Cs7lyeJ3PPzg7xQg\",\"name\":\"probe\",\"simple_trigger\":{\"device_id\":\"KqYJ16Cs7lyeJ3PPzg7xQg\",\"on\":\"device_error\",\"type\":\"device_trigger\"}}",
+      "reply": "[\"1\",\"2\",\"rooms:bench:probe\",\"phx_reply\",{\"status\":\"ok\",\"response\":{}}]",
+      "accepted": true
+    },
+    {
+      "name": "watch device_trigger, claim WATCH::\u003canother device\u003e",
+      "why": "The paired refusal for the row above: a well-formed claim naming a different device. Together they show the device id is really the string being matched, rather than the acceptance coming from any claim at all.",
+      "a_ch_claims": [
+        "JOIN::.*",
+        "WATCH::aaaaaaaaaaaaaaaaaaaaaa"
+      ],
+      "operation": "watch",
+      "payload": "{\"device_id\":\"KqYJ16Cs7lyeJ3PPzg7xQg\",\"name\":\"probe\",\"simple_trigger\":{\"device_id\":\"KqYJ16Cs7lyeJ3PPzg7xQg\",\"on\":\"device_error\",\"type\":\"device_trigger\"}}",
       "reply": "[\"1\",\"2\",\"rooms:bench:probe\",\"phx_reply\",{\"status\":\"error\",\"response\":{\"reason\":\"unauthorized\"}}]",
       "accepted": false
     }

--- a/test/conformance/upstream/channels.transcript.txt
+++ b/test/conformance/upstream/channels.transcript.txt
@@ -1,4 +1,4 @@
-# Channels transcript, recorded 2026-07-26T20:53:09Z
+# Channels transcript, recorded 2026-07-26T22:34:04Z
 # upstream http://api.astarte.localhost:8080 realm "bench" device "KqYJ16Cs7lyeJ3PPzg7xQg"
 # socket: /appengine/v1/socket/websocket?vsn=2.0.0&realm=<realm>&token=<a_ch JWT>
 # The token is never printed; it is a realm-signed JWT carrying only the a_ch claims named per row.
@@ -63,175 +63,32 @@
   <- ["1","2","rooms:bench:probe","phx_reply",{"status":"error","response":{"reason":"unauthorized"}}]
   accepted: false
 
-## device_error: what upstream calls each rejection
-# One fresh websocket and one fresh device session per row. Several of these
-# provocations make upstream force a clean session and disconnect the device,
-# so a shared session would record the first row honestly and the rest as silence.
+### watch data_trigger, claim WATCH::<device>/<interface> (Astrate's shape)
+  a_ch: [JOIN::.* WATCH::KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Individual]
+  op: watch
+  payload: {"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","name":"probe","simple_trigger":{"interface_major":1,"interface_name":"org.astrate.bench.Individual","match_path":"/value","on":"incoming_data","type":"data_trigger","value_match_operator":"*"}}
+  <- ["1","2","rooms:bench:probe","phx_reply",{"status":"error","response":{"reason":"unauthorized"}}]
+  accepted: false
 
-### valid publish
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Individual/value
-  payload (base64): EAAAAAF2AAAAAAAAAEVAAA==
-  (no device_error reached the room on this attempt)
+### watch data_trigger, claim WATCH::<device>/<interface><match_path>
+  a_ch: [JOIN::.* WATCH::KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Individual/value]
+  op: watch
+  payload: {"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","name":"probe","simple_trigger":{"interface_major":1,"interface_name":"org.astrate.bench.Individual","match_path":"/value","on":"incoming_data","type":"data_trigger","value_match_operator":"*"}}
+  <- ["1","2","rooms:bench:probe","phx_reply",{"status":"ok","response":{}}]
+  accepted: true
 
-### valid publish
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Individual/value
-  payload (base64): EAAAAAF2AAAAAAAAAEVAAA==
-  (uncorrelated, belongs to the session) <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"device_session_not_found","metadata":{},"type":"device_error"},"timestamp":"2026-07-26T20:53:48.830Z"}]
-  (no device_error reached the room on this attempt)
+### watch device_trigger, claim WATCH::<this device>
+  a_ch: [JOIN::.* WATCH::KqYJ16Cs7lyeJ3PPzg7xQg]
+  op: watch
+  payload: {"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","name":"probe","simple_trigger":{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","on":"device_error","type":"device_trigger"}}
+  <- ["1","2","rooms:bench:probe","phx_reply",{"status":"ok","response":{}}]
+  accepted: true
 
-### valid publish
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Individual/value
-  payload (base64): EAAAAAF2AAAAAAAAAEVAAA==
-  (no device_error reached the room on this attempt)
-  => valid publish: (never reached the room), delivered 0/3
+### watch device_trigger, claim WATCH::<another device>
+  a_ch: [JOIN::.* WATCH::aaaaaaaaaaaaaaaaaaaaaa]
+  op: watch
+  payload: {"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","name":"probe","simple_trigger":{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","on":"device_error","type":"device_trigger"}}
+  <- ["1","2","rooms:bench:probe","phx_reply",{"status":"error","response":{"reason":"unauthorized"}}]
+  accepted: false
 
-### interface not in introspection
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.nonexistent.Iface/value
-  payload (base64): EAAAAAF2AAAAAAAAAPA/AA==
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"interface_loading_failed","metadata":{"base64_payload":"EAAAAAF2AAAAAAAAAPA/AA==","interface":"\"org.astrate.nonexistent.Iface\"","path":"\"/value\""},"type":"device_error"},"timestamp":"2026-07-26T20:54:39.413Z"}]
-
-### interface not in introspection
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.nonexistent.Iface/value
-  payload (base64): EAAAAAF2AAAAAAAAAPA/AA==
-  (uncorrelated, belongs to the session) <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"device_session_not_found","metadata":{},"type":"device_error"},"timestamp":"2026-07-26T20:55:07.678Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"interface_loading_failed","metadata":{"base64_payload":"EAAAAAF2AAAAAAAAAPA/AA==","interface":"\"org.astrate.nonexistent.Iface\"","path":"\"/value\""},"type":"device_error"},"timestamp":"2026-07-26T20:55:07.678Z"}]
-
-### interface not in introspection
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.nonexistent.Iface/value
-  payload (base64): EAAAAAF2AAAAAAAAAPA/AA==
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"interface_loading_failed","metadata":{"base64_payload":"EAAAAAF2AAAAAAAAAPA/AA==","interface":"\"org.astrate.nonexistent.Iface\"","path":"\"/value\""},"type":"device_error"},"timestamp":"2026-07-26T20:55:35.939Z"}]
-  (uncorrelated, belongs to the session) <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"device_session_not_found","metadata":{},"type":"device_error"},"timestamp":"2026-07-26T20:55:35.939Z"}]
-  => interface not in introspection: interface_loading_failed, delivered 3/3
-
-### unknown path on a known interface
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Individual/nosuchpath
-  payload (base64): EAAAAAF2AAAAAAAAAPA/AA==
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"mapping_not_found","metadata":{"base64_payload":"EAAAAAF2AAAAAAAAAPA/AA==","interface":"\"org.astrate.bench.Individual\"","path":"\"/nosuchpath\""},"type":"device_error"},"timestamp":"2026-07-26T20:55:58.587Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"mapping_not_found","metadata":{"base64_payload":"EAAAAAF2AAAAAAAAAPA/AA==","interface":"\"org.astrate.bench.Individual\"","path":"\"/nosuchpath\""},"type":"device_error"},"timestamp":"2026-07-26T20:56:06.758Z"}]
-
-### unknown path on a known interface
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Individual/nosuchpath
-  payload (base64): EAAAAAF2AAAAAAAAAPA/AA==
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"mapping_not_found","metadata":{"base64_payload":"EAAAAAF2AAAAAAAAAPA/AA==","interface":"\"org.astrate.bench.Individual\"","path":"\"/nosuchpath\""},"type":"device_error"},"timestamp":"2026-07-26T20:56:29.409Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"mapping_not_found","metadata":{"base64_payload":"EAAAAAF2AAAAAAAAAPA/AA==","interface":"\"org.astrate.bench.Individual\"","path":"\"/nosuchpath\""},"type":"device_error"},"timestamp":"2026-07-26T20:56:37.585Z"}]
-
-### unknown path on a known interface
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Individual/nosuchpath
-  payload (base64): EAAAAAF2AAAAAAAAAPA/AA==
-  (uncorrelated, belongs to the session) <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"device_session_not_found","metadata":{},"type":"device_error"},"timestamp":"2026-07-26T20:57:05.866Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"mapping_not_found","metadata":{"base64_payload":"EAAAAAF2AAAAAAAAAPA/AA==","interface":"\"org.astrate.bench.Individual\"","path":"\"/nosuchpath\""},"type":"device_error"},"timestamp":"2026-07-26T20:57:05.866Z"}]
-  => unknown path on a known interface: mapping_not_found, delivered 3/3
-
-### payload that is not BSON at all
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Individual/value
-  payload (base64): ZGVmaW5pdGVseSBub3QgYnNvbg==
-  (uncorrelated, belongs to the session) <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"device_session_not_found","metadata":{},"type":"device_error"},"timestamp":"2026-07-26T20:57:34.215Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"undecodable_bson_payload","metadata":{"base64_payload":"ZGVmaW5pdGVseSBub3QgYnNvbg==","interface":"\"org.astrate.bench.Individual\"","path":"\"/value\""},"type":"device_error"},"timestamp":"2026-07-26T20:57:34.215Z"}]
-
-### payload that is not BSON at all
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Individual/value
-  payload (base64): ZGVmaW5pdGVseSBub3QgYnNvbg==
-  (no device_error reached the room on this attempt)
-
-### payload that is not BSON at all
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Individual/value
-  payload (base64): ZGVmaW5pdGVseSBub3QgYnNvbg==
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"undecodable_bson_payload","metadata":{"base64_payload":"ZGVmaW5pdGVseSBub3QgYnNvbg==","interface":"\"org.astrate.bench.Individual\"","path":"\"/value\""},"type":"device_error"},"timestamp":"2026-07-26T20:58:19.079Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"undecodable_bson_payload","metadata":{"base64_payload":"ZGVmaW5pdGVseSBub3QgYnNvbg==","interface":"\"org.astrate.bench.Individual\"","path":"\"/value\""},"type":"device_error"},"timestamp":"2026-07-26T20:58:19.171Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"undecodable_bson_payload","metadata":{"base64_payload":"ZGVmaW5pdGVseSBub3QgYnNvbg==","interface":"\"org.astrate.bench.Individual\"","path":"\"/value\""},"type":"device_error"},"timestamp":"2026-07-26T20:58:20.274Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"undecodable_bson_payload","metadata":{"base64_payload":"ZGVmaW5pdGVseSBub3QgYnNvbg==","interface":"\"org.astrate.bench.Individual\"","path":"\"/value\""},"type":"device_error"},"timestamp":"2026-07-26T20:58:22.443Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"undecodable_bson_payload","metadata":{"base64_payload":"ZGVmaW5pdGVseSBub3QgYnNvbg==","interface":"\"org.astrate.bench.Individual\"","path":"\"/value\""},"type":"device_error"},"timestamp":"2026-07-26T20:58:26.634Z"}]
-  => payload that is not BSON at all: undecodable_bson_payload, delivered 2/3
-
-### string where the mapping says double
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Individual/value
-  payload (base64): EgAAAAJ2AAYAAABoZWxsbwAA
-  (no device_error reached the room on this attempt)
-
-### string where the mapping says double
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Individual/value
-  payload (base64): EgAAAAJ2AAYAAABoZWxsbwAA
-  (uncorrelated, belongs to the session) <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"device_session_not_found","metadata":{},"type":"device_error"},"timestamp":"2026-07-26T20:59:09.866Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"unexpected_value_type","metadata":{"base64_payload":"EgAAAAJ2AAYAAABoZWxsbwAA","interface":"\"org.astrate.bench.Individual\"","path":"\"/value\""},"type":"device_error"},"timestamp":"2026-07-26T20:59:09.866Z"}]
-
-### string where the mapping says double
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Individual/value
-  payload (base64): EgAAAAJ2AAYAAABoZWxsbwAA
-  (no device_error reached the room on this attempt)
-  => string where the mapping says double: unexpected_value_type, delivered 1/3
-
-### BSON document with no v key
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Individual/value
-  payload (base64): EAAAAAF4AAAAAAAAAPA/AA==
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"unexpected_value_type","metadata":{"base64_payload":"EAAAAAF4AAAAAAAAAPA/AA==","interface":"\"org.astrate.bench.Individual\"","path":"\"/value\""},"type":"device_error"},"timestamp":"2026-07-26T20:59:54.825Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"unexpected_value_type","metadata":{"base64_payload":"EAAAAAF4AAAAAAAAAPA/AA==","interface":"\"org.astrate.bench.Individual\"","path":"\"/value\""},"type":"device_error"},"timestamp":"2026-07-26T20:59:54.912Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"unexpected_value_type","metadata":{"base64_payload":"EAAAAAF4AAAAAAAAAPA/AA==","interface":"\"org.astrate.bench.Individual\"","path":"\"/value\""},"type":"device_error"},"timestamp":"2026-07-26T20:59:56.040Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"unexpected_value_type","metadata":{"base64_payload":"EAAAAAF4AAAAAAAAAPA/AA==","interface":"\"org.astrate.bench.Individual\"","path":"\"/value\""},"type":"device_error"},"timestamp":"2026-07-26T20:59:58.190Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"unexpected_value_type","metadata":{"base64_payload":"EAAAAAF4AAAAAAAAAPA/AA==","interface":"\"org.astrate.bench.Individual\"","path":"\"/value\""},"type":"device_error"},"timestamp":"2026-07-26T21:00:02.309Z"}]
-
-### BSON document with no v key
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Individual/value
-  payload (base64): EAAAAAF4AAAAAAAAAPA/AA==
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"unexpected_value_type","metadata":{"base64_payload":"EAAAAAF4AAAAAAAAAPA/AA==","interface":"\"org.astrate.bench.Individual\"","path":"\"/value\""},"type":"device_error"},"timestamp":"2026-07-26T21:00:17.345Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"unexpected_value_type","metadata":{"base64_payload":"EAAAAAF4AAAAAAAAAPA/AA==","interface":"\"org.astrate.bench.Individual\"","path":"\"/value\""},"type":"device_error"},"timestamp":"2026-07-26T21:00:25.528Z"}]
-
-### BSON document with no v key
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Individual/value
-  payload (base64): EAAAAAF4AAAAAAAAAPA/AA==
-  (no device_error reached the room on this attempt)
-  => BSON document with no v key: unexpected_value_type, delivered 2/3
-
-### object with an unexpected key
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Object/data
-  payload (base64): LgAAAAN2ACYAAAABdGVtcAAAAAAAAADwPwFib2d1c19rZXkAAAAAAAAAAEAAAA==
-  (uncorrelated, belongs to the session) <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"device_session_not_found","metadata":{},"type":"device_error"},"timestamp":"2026-07-26T21:01:16.112Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"unexpected_object_key","metadata":{"base64_payload":"LgAAAAN2ACYAAAABdGVtcAAAAAAAAADwPwFib2d1c19rZXkAAAAAAAAAAEAAAA==","interface":"\"org.astrate.bench.Object\"","path":"\"/data\""},"type":"device_error"},"timestamp":"2026-07-26T21:01:16.113Z"}]
-
-### object with an unexpected key
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Object/data
-  payload (base64): LgAAAAN2ACYAAAABdGVtcAAAAAAAAADwPwFib2d1c19rZXkAAAAAAAAAAEAAAA==
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"unexpected_object_key","metadata":{"base64_payload":"LgAAAAN2ACYAAAABdGVtcAAAAAAAAADwPwFib2d1c19rZXkAAAAAAAAAAEAAAA==","interface":"\"org.astrate.bench.Object\"","path":"\"/data\""},"type":"device_error"},"timestamp":"2026-07-26T21:01:38.762Z"}]
-
-### object with an unexpected key
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/org.astrate.bench.Object/data
-  payload (base64): LgAAAAN2ACYAAAABdGVtcAAAAAAAAADwPwFib2d1c19rZXkAAAAAAAAAAEAAAA==
-  (uncorrelated, belongs to the session) <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"device_session_not_found","metadata":{},"type":"device_error"},"timestamp":"2026-07-26T21:02:06.700Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"unexpected_object_key","metadata":{"base64_payload":"LgAAAAN2ACYAAAABdGVtcAAAAAAAAADwPwFib2d1c19rZXkAAAAAAAAAAEAAAA==","interface":"\"org.astrate.bench.Object\"","path":"\"/data\""},"type":"device_error"},"timestamp":"2026-07-26T21:02:06.700Z"}]
-  => object with an unexpected key: unexpected_object_key, delivered 3/3
-
-### unknown control message
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/control/bogusControl
-  payload (base64): MQ==
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"unexpected_control_message","metadata":{"base64_payload":"MQ==","path":"\"/bogusControl\""},"type":"device_error"},"timestamp":"2026-07-26T21:02:34.547Z"}]
-
-### unknown control message
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/control/bogusControl
-  payload (base64): MQ==
-  (no device_error reached the room on this attempt)
-
-### unknown control message
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg/control/bogusControl
-  payload (base64): MQ==
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"unexpected_control_message","metadata":{"base64_payload":"MQ==","path":"\"/bogusControl\""},"type":"device_error"},"timestamp":"2026-07-26T21:03:26.166Z"}]
-  => unknown control message: unexpected_control_message, delivered 2/3
-
-### invalid introspection
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg
-  payload (base64): dGhpcyBpcyBub3QgYW4gaW50cm9zcGVjdGlvbg==
-  (no device_error reached the room on this attempt)
-
-### invalid introspection
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg
-  payload (base64): dGhpcyBpcyBub3QgYW4gaW50cm9zcGVjdGlvbg==
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"invalid_introspection","metadata":{"base64_payload":"dGhpcyBpcyBub3QgYW4gaW50cm9zcGVjdGlvbg=="},"type":"device_error"},"timestamp":"2026-07-26T21:04:11.645Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"invalid_introspection","metadata":{"base64_payload":"dGhpcyBpcyBub3QgYW4gaW50cm9zcGVjdGlvbg=="},"type":"device_error"},"timestamp":"2026-07-26T21:04:11.736Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"invalid_introspection","metadata":{"base64_payload":"dGhpcyBpcyBub3QgYW4gaW50cm9zcGVjdGlvbg=="},"type":"device_error"},"timestamp":"2026-07-26T21:04:12.853Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"invalid_introspection","metadata":{"base64_payload":"dGhpcyBpcyBub3QgYW4gaW50cm9zcGVjdGlvbg=="},"type":"device_error"},"timestamp":"2026-07-26T21:04:15.001Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"invalid_introspection","metadata":{"base64_payload":"dGhpcyBpcyBub3QgYW4gaW50cm9zcGVjdGlvbg=="},"type":"device_error"},"timestamp":"2026-07-26T21:04:19.101Z"}]
-
-### invalid introspection
-  topic: bench/KqYJ16Cs7lyeJ3PPzg7xQg
-  payload (base64): dGhpcyBpcyBub3QgYW4gaW50cm9zcGVjdGlvbg==
-  (uncorrelated, belongs to the session) <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"device_session_not_found","metadata":{},"type":"device_error"},"timestamp":"2026-07-26T21:04:39.908Z"}]
-  <- [null,null,"rooms:bench:probe","new_event",{"device_id":"KqYJ16Cs7lyeJ3PPzg7xQg","event":{"error_name":"invalid_introspection","metadata":{"base64_payload":"dGhpcyBpcyBub3QgYW4gaW50cm9zcGVjdGlvbg=="},"type":"device_error"},"timestamp":"2026-07-26T21:04:39.908Z"}]
-  => invalid introspection: invalid_introspection, delivered 2/3
+# section=auth — the other section was carried over unchanged from upstream/channels.json

--- a/test/conformance/upstream/recordchannels/main.go
+++ b/test/conformance/upstream/recordchannels/main.go
@@ -98,6 +98,11 @@ const (
 	ifaceIndividual = "org.astrate.bench.Individual" // /value, double
 	ifaceObject     = "org.astrate.bench.Object"     // /data/{temp,hum,status}
 	introspection   = ifaceIndividual + ":1:0;" + ifaceObject + ":1:0"
+
+	// otherDeviceID is a well-formed device id that is deliberately NOT the
+	// device this recorder drives. It exists to pair a narrow WATCH claim's
+	// acceptance with a refusal that differs only in which device is named.
+	otherDeviceID = "aaaaaaaaaaaaaaaaaaaaaa"
 )
 
 // --------------------------------------------------------------- the fixture
@@ -210,8 +215,21 @@ func run() error {
 		SocketPath:      "/appengine/v1/socket/websocket?vsn=2.0.0&realm=<realm>&token=<a_ch JWT>",
 	}
 
-	fx.Authorization = recordAuthorization(dev.ID)
-	fx.DeviceErrors = recordDeviceErrors(dev)
+	// ASTARTE_UPSTREAM_SECTION re-records one section and carries the other over
+	// from the committed fixture. Delivery of device_error to the room is
+	// unreliable on this stack (see the README), so a full re-run to settle an
+	// authorization question would churn attempts/delivered counts that were
+	// measured carefully and are not what is being asked about.
+	section := env("ASTARTE_UPSTREAM_SECTION", "all")
+	if section != "all" && section != "auth" && section != "errors" {
+		return fmt.Errorf("ASTARTE_UPSTREAM_SECTION must be all, auth or errors (got %q)", section)
+	}
+	if section != "errors" {
+		fx.Authorization = recordAuthorization(dev.ID)
+	}
+	if section != "auth" {
+		fx.DeviceErrors = recordDeviceErrors(dev)
+	}
 
 	// Resolve the output directory rather than guessing from the working
 	// directory: `go run ./upstream/recordchannels` and `go run .` from inside
@@ -231,6 +249,30 @@ func run() error {
 	}
 	jsonPath := filepath.Join(dir, "channels.json")
 	txtPath := filepath.Join(dir, "channels.transcript.txt")
+
+	// Carry the un-recorded section over from the committed fixture, and refuse
+	// to write a fixture with a section missing — a half-empty channels.json
+	// would look like "upstream does nothing here" to every later reader.
+	if section != "all" {
+		var prev fixture
+		b, err := os.ReadFile(jsonPath)
+		if err != nil {
+			return fmt.Errorf("reading %s to carry over the other section: %w", jsonPath, err)
+		}
+		if err := json.Unmarshal(b, &prev); err != nil {
+			return fmt.Errorf("parsing %s: %w", jsonPath, err)
+		}
+		if section == "auth" {
+			fx.DeviceErrors = prev.DeviceErrors
+		} else {
+			fx.Authorization = prev.Authorization
+		}
+		logf("\n# section=%s — the other section was carried over unchanged from %s", section, jsonPath)
+	}
+	if len(fx.Authorization) == 0 || len(fx.DeviceErrors) == 0 {
+		return fmt.Errorf("refusing to write a fixture with an empty section "+
+			"(authorization=%d, device_errors=%d)", len(fx.Authorization), len(fx.DeviceErrors))
+	}
 
 	out, err := json.MarshalIndent(fx, "", "  ")
 	if err != nil {
@@ -283,6 +325,21 @@ func recordAuthorization(deviceID string) []authObservation {
 	dataTrigger := map[string]any{"name": "probe", "device_id": deviceID,
 		"simple_trigger": map[string]any{"type": "data_trigger", "on": "incoming_data",
 			"interface_name": "*", "match_path": "/*", "value_match_operator": "*"}}
+	// pathTrigger names a concrete interface and match path, because the narrow
+	// claims below have to be written as regexes: the wildcards in dataTrigger
+	// would make the claim match by accident and prove nothing.
+	//
+	// interface_major is required as soon as interface_name is not "*", and
+	// omitting it is not an authorization failure but a *validation* one —
+	// `{"errors":{"simple_trigger":{"interface_major":["can't be blank"]}}}`.
+	// That reply is a refusal like any other to a recorder that only checks for
+	// "status":"ok", so both narrow rows would have been recorded as refused and
+	// read as evidence about the authorization path. They are not: a validation
+	// error is returned before authorization is consulted at all.
+	pathTrigger := map[string]any{"name": "probe", "device_id": deviceID,
+		"simple_trigger": map[string]any{"type": "data_trigger", "on": "incoming_data",
+			"interface_name": ifaceIndividual, "interface_major": 1,
+			"match_path": "/value", "value_match_operator": "*"}}
 
 	rows := []authObservation{
 		join("join with blanket .*::.*",
@@ -314,6 +371,29 @@ func recordAuthorization(deviceID string) []authObservation {
 		watch("watch device_trigger for device_id \"*\"",
 			"A wildcard device is refused even under WATCH::.*, so device triggers cannot be watched realm-wide from a room.",
 			[]string{"JOIN::.*", "WATCH::.*"}, devTrigger("device_error", "*")),
+
+		// The rows above all used WATCH::.*, which accepts whatever string
+		// upstream builds and therefore cannot say what that string IS. These
+		// use narrow claims, so an acceptance identifies the authorization path
+		// and a refusal excludes a candidate. Astrate builds
+		// "<device>/<interface>"; upstream's source appends the trigger's match
+		// path. Only one of the next two rows can be accepted.
+		watch("watch data_trigger, claim WATCH::<device>/<interface> (Astrate's shape)",
+			"Astrate authorizes a data trigger against `<device_id>/<interface>`, with no match path. If upstream built the same string this is accepted; if upstream appends the match path it is refused, because the anchored claim regex cannot match the longer string.",
+			[]string{"JOIN::.*", "WATCH::" + deviceID + "/" + ifaceIndividual},
+			pathTrigger),
+		watch("watch data_trigger, claim WATCH::<device>/<interface><match_path>",
+			"The paired alternative, and upstream's shape according to its source (`\"#{device_id}/#{interface_name}#{path}\"`, with no separator because the path already starts with a slash). Exactly one of this row and the one above can be accepted, so together they identify the authorization path rather than merely confirming a guess.",
+			[]string{"JOIN::.*", "WATCH::" + deviceID + "/" + ifaceIndividual + "/value"},
+			pathTrigger),
+		watch("watch device_trigger, claim WATCH::<this device>",
+			"A device trigger's authorization path is claimed to be the bare device id. A narrow, exact claim accepts it, which is what identifies the path.",
+			[]string{"JOIN::.*", "WATCH::" + deviceID},
+			devTrigger("device_error", deviceID)),
+		watch("watch device_trigger, claim WATCH::<another device>",
+			"The paired refusal for the row above: a well-formed claim naming a different device. Together they show the device id is really the string being matched, rather than the acceptance coming from any claim at all.",
+			[]string{"JOIN::.*", "WATCH::" + otherDeviceID},
+			devTrigger("device_error", deviceID)),
 	}
 
 	for _, r := range rows {
@@ -323,8 +403,24 @@ func recordAuthorization(deviceID string) []authObservation {
 		}
 		logf("  <- %s", r.Reply)
 		logf("  accepted: %v", r.Accepted)
+		if validationRefusal(r.Reply) {
+			// Loud on purpose. Upstream validates the payload before it consults
+			// the token, so this row was refused for a reason that has nothing to
+			// do with its claim — but it is a refusal like any other to a reader
+			// scanning for "accepted: false", and reading it as evidence about
+			// authorization is exactly how a recorder invents a finding.
+			logf("  !! VALIDATION ERROR, NOT AN AUTHORIZATION REFUSAL — this row says")
+			logf("  !! nothing about the a_ch grammar. Fix the payload and re-record.")
+		}
 	}
 	return rows
+}
+
+// validationRefusal reports whether a refusal came from upstream's changeset
+// validation rather than from authorization. An authorization refusal carries
+// {"reason":"unauthorized"}; a validation refusal carries {"errors":{…}}.
+func validationRefusal(reply string) bool {
+	return strings.Contains(reply, `"status":"error"`) && strings.Contains(reply, `"errors":`)
 }
 
 // attempt opens a socket with the given claims, joins, optionally watches, and


### PR DESCRIPTION
Stacked on #4 (`worktree-m12-06-ach-join`). Settles the two divergences #4 recorded but deliberately left unreconciled.

## The measurement

Phase 04b's rows all used `WATCH::.*`, which accepts whatever string upstream builds and so cannot say what that string *is*. These use narrow claims, where exactly one of each pair can be accepted:

| trigger | claim | |
| --- | --- | --- |
| data trigger on `/value` | `WATCH::<device>/<interface>` | refused |
| data trigger on `/value` | `WATCH::<device>/<interface>/value` | **accepted** |
| device trigger | `WATCH::<that device>` | **accepted** |
| device trigger | `WATCH::<another device>` | refused |

Both passes of the final recording agree on all 13 rows.

## What changed in Astrate

- A data trigger authorizes against `<device_id>/<interface_name><match_path>` (no separator — the match path carries its own slash). Astrate built `<device_id>/<interface_name>`, wrong in **both** directions: it refused claims upstream accepts and accepted claims upstream refuses.
- A device trigger must name its device inside `simple_trigger`, and it must equal the request's `device_id`. Upstream refuses a top-level-only `device_id` and the wildcard `"*"` as `unauthorized`; Astrate accepted both.
- Group shapes follow the same upstream function but are **not measured** (the realm has no group) and are labelled as such rather than presented as parity.

## Recorder changes

- `ASTARTE_UPSTREAM_SECTION=auth|errors|all` re-records one section and carries the other over, refusing to write a fixture with an empty section. `device_error` delivery is unreliable on this stack, so a full re-run to settle an authorization question would churn `attempts`/`delivered` counts that were measured carefully.
- A refusal carrying `"errors"` rather than `"reason"` now prints `!! VALIDATION ERROR, NOT AN AUTHORIZATION REFUSAL`.

**That trap cost this recording a pass.** A missing `interface_major` made *both* narrow data-trigger rows come back refused — coherent, readable, and meaningless, since upstream validates the payload before consulting the token. Recorded as-is it would have "shown" that neither shape is the authorization path.

## Verification

`go test -race ./...` green, lint clean, gofmt clean. Both rules mutation-checked, with restores verified positively rather than by `git checkout`:

| mutation | red |
| --- | --- |
| drop the match path (Astrate's old shape) | 2 `TestWatchAuthPath` rows + both `TestWireSession_WatchPathIsMatchPathScoped` rows |
| accept a device trigger not naming the request's device | 3 `TestWatchAuthPath` rows |