### PR TITLE
appengine e2e: fix TestChannelsLiveEvents claim after a_ch grammar change

### DIFF
--- a/docs/embed.go
+++ b/docs/embed.go
@@ -9,7 +9,7 @@ import "embed"
 //go:embed swagger-ui/*
 var SwaggerUI embed.FS
 
-// API holds the OpenAPI 3.0 YAML specifications for all five API surfaces.
+// APIYAML holds the OpenAPI 3.0 YAML specifications for all five API surfaces.
 //
 //go:embed api/*.yaml
 var APIYAML embed.FS

--- a/internal/appengine/e2e_test.go
+++ b/internal/appengine/e2e_test.go
@@ -237,7 +237,7 @@ func TestChannelsLiveEvents(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	claims := jwt.MapClaims{"a_ch": []string{".*::.*"}, "exp": time.Now().Add(time.Hour).Unix()}
+	claims := jwt.MapClaims{"a_ch": []string{"JOIN::.*", "WATCH::.*"}, "exp": time.Now().Add(time.Hour).Unix()}
 	token, err := jwt.NewWithClaims(jwt.SigningMethodRS256, claims).SignedString(env.jwtKey)
 	if err != nil {
 		t.Fatalf("sign token: %v", err)


### PR DESCRIPTION
Follow-up to #4 (merged). \`TestChannelsLiveEvents\` minted an \`a_ch\` claim of
\`.*::.*\`, which the new literal Channels grammar reads as "authorizes
nothing" — the socket partitions \`a_ch\` entries by an exact match on the verb
field (\`JOIN\`/\`WATCH\`), never a regex. The test has been red on \`main\` since
#4 merged (\`phx_join\` replies \`{"reason":"unauthorized"}\`).

Fix: mint \`["JOIN::.*", "WATCH::.*"]\` instead — the shape upstream actually
reads, per \`test/conformance/upstream/channels.json\`.

No production code changed; this only restores the test to green.