### PR TITLE
M12-07: toolkit lttb() downsampling, time_bucket+avg as the always-available fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,10 @@ jobs:
     timeout-minutes: 45
     services:
       timescaledb:
-        image: timescale/timescaledb:latest-pg16
+        # -ha, not the plain image: it is the only one carrying
+        # timescaledb_toolkit, and CI must exercise the lttb() downsampling
+        # path on the same image developers run locally (docker-compose.yml).
+        image: timescale/timescaledb-ha:pg16
         env:
           POSTGRES_DB: astrate
           POSTGRES_USER: astrate
@@ -103,7 +106,10 @@ jobs:
     timeout-minutes: 90
     services:
       timescaledb:
-        image: timescale/timescaledb:latest-pg16
+        # -ha, not the plain image: it is the only one carrying
+        # timescaledb_toolkit, and CI must exercise the lttb() downsampling
+        # path on the same image developers run locally (docker-compose.yml).
+        image: timescale/timescaledb-ha:pg16
         env:
           POSTGRES_DB: astrate
           POSTGRES_USER: astrate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,14 @@
 # Credentials and the master key below are throwaway local-dev values.
 services:
   timescaledb:
-    image: timescale/timescaledb:latest-pg16
+    # The -ha image rather than the plain one, because it is the only published
+    # image carrying timescaledb_toolkit — and so the only one on which the
+    # lttb() downsampling path can execute at all (docs/DESIGN.md §2.5). Two
+    # consequences, both load-bearing: PGDATA moves to
+    # /home/postgres/pgdata/data, and the container runs as `postgres` rather
+    # than root, so this mounts a *new* volume name — pointing the old
+    # root-written `pgdata` at it fails on permissions.
+    image: timescale/timescaledb-ha:pg16
     command:
       - postgres
       - -c
@@ -37,7 +44,7 @@ services:
     ports:
       - "127.0.0.1:5432:5432"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata_ha:/home/postgres/pgdata/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U astrate -d astrate"]
       interval: 5s
@@ -92,5 +99,8 @@ services:
       - ./deploy/dashboard/config.json:/usr/share/nginx/html/user-config/config.json:ro
 
 volumes:
-  pgdata:
+  # Renamed from `pgdata` when the image moved to -ha: the old volume holds a
+  # data directory written by root at the old PGDATA path, and neither the
+  # ownership nor the location matches what this image expects.
+  pgdata_ha:
   sessions:

--- a/internal/appengine/data.go
+++ b/internal/appengine/data.go
@@ -140,6 +140,18 @@ func (s *Service) datastreamData(ctx context.Context, r *resolved, path string, 
 		if !ok {
 			return []Sample{}, nil
 		}
+		// lttb rejects resolution < 3, but downsample_to permits 2 — fall back to bucket path.
+		if s.st.HasToolkitLTTB() && opts.DownsamplePoints >= 3 {
+			points, err := s.st.DownsampleLTTB(ctx, q, opts.DownsamplePoints)
+			if err != nil {
+				return nil, err
+			}
+			out := make([]Sample, len(points))
+			for i := range points {
+				out[i] = Sample{Value: points[i].Value, Timestamp: points[i].Bucket}
+			}
+			return out, nil
+		}
 		bucket := bucketFor(last.Sub(first), opts.DownsamplePoints)
 		if bucket <= 0 {
 			// A zero-span series (one sample or simultaneous samples) produces

--- a/internal/appengine/http_test.go
+++ b/internal/appengine/http_test.go
@@ -301,6 +301,20 @@ func TestAppEngine(t *testing.T) {
 			}
 		}
 
+		// downsample_to=2 is legal (the parser only rejects < 2), but toolkit
+		// lttb() refuses a resolution below 3 outright — "resolution must be
+		// greater than 2". On a toolkit-bearing server the service must fall
+		// back to the time_bucket path for it rather than surface a 500.
+		var two []Sample
+		rec := r.req(t, http.MethodGet, path+"?downsample_to=2&sort=ascending", "", r.token)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("downsample_to=2: got %d, want 200 (body %s)", rec.Code, rec.Body.String())
+		}
+		decodeData(t, rec, &two)
+		if len(two) == 0 {
+			t.Error("downsample_to=2 returned no points")
+		}
+
 		// store.Downsample reads the individual-datastream table only, so an
 		// object-aggregated interface cannot be downsampled. Saying so is the
 		// point: without the check it would silently return an empty array.

--- a/internal/store/datastreams.go
+++ b/internal/store/datastreams.go
@@ -298,10 +298,8 @@ type DownsamplePoint struct {
 // point per bucket via TimescaleDB time_bucket (AppEngine downsample_to,
 // docs/DESIGN.md §2.5). Non-numeric rows in the window are ignored.
 //
-// TODO(extension point, docs/ROADMAP.md §0.1 rule 3 / docs/DESIGN.md §2.5):
-// when s.hasToolkit is set (timescaledb_toolkit probed at startup), switch to
-// toolkit lttb() for shape-preserving downsampling; this time_bucket+avg
-// path is the always-available default and stays as the fallback.
+// This is the always-available fallback; the toolkit path lives in
+// DownsampleLTTB which callers prefer when Store.HasToolkitLTTB is true.
 func (s *Store) Downsample(ctx context.Context, q SeriesQuery, bucket time.Duration) ([]DownsamplePoint, error) {
 	if bucket <= 0 {
 		return nil, fmt.Errorf("store: downsample bucket must be positive, got %s", bucket)
@@ -324,6 +322,56 @@ func (s *Store) Downsample(ctx context.Context, q SeriesQuery, bucket time.Durat
 		%s
 		  AND (value_double IS NOT NULL OR value_integer IS NOT NULL OR value_longinteger IS NOT NULL)
 		GROUP BY bucket`+order+limit, len(args), where), args...)
+	if err != nil {
+		return nil, fmt.Errorf("store: downsampling series %s: %w", q.Path, err)
+	}
+	defer rows.Close()
+
+	var out []DownsamplePoint
+	for rows.Next() {
+		var p DownsamplePoint
+		if err := rows.Scan(&p.Bucket, &p.Value); err != nil {
+			return nil, fmt.Errorf("store: scanning downsample row: %w", err)
+		}
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("store: reading downsample of %s: %w", q.Path, err)
+	}
+	return out, nil
+}
+
+// DownsampleLTTB reduces a numeric individual-datastream series to at most
+// points samples using timescaledb_toolkit's lttb() (Largest-Triangle-Three-
+// Buckets), which preserves the visual shape of the curve by selecting real
+// samples rather than averaging them away.
+//
+// It requires the toolkit: callers must check Store.HasToolkitLTTB first and
+// fall back to Downsample when it is absent (docs/DESIGN.md §2.5). points must
+// be at least 3 — lttb rejects a smaller resolution outright.
+func (s *Store) DownsampleLTTB(ctx context.Context, q SeriesQuery, points int) ([]DownsamplePoint, error) {
+	if points < 3 {
+		return nil, fmt.Errorf("store: downsample lttb needs at least 3 points, got %d", points)
+	}
+	where, args := q.where()
+	args = append(args, points)
+	order := " ORDER BY time ASC"
+	if q.Descending {
+		order = " ORDER BY time DESC"
+	}
+	limit := ""
+	if q.Limit > 0 {
+		limit = " LIMIT " + strconv.Itoa(q.Limit)
+	}
+
+	rows, err := s.pool.Query(ctx, fmt.Sprintf(`
+		SELECT time, value
+		FROM unnest((
+			SELECT lttb(ts, coalesce(value_double, value_integer::double precision, value_longinteger::double precision), $%d)
+			FROM individual_datastreams
+			%s
+			  AND (value_double IS NOT NULL OR value_integer IS NOT NULL OR value_longinteger IS NOT NULL)
+		))`+order+limit, len(args), where), args...)
 	if err != nil {
 		return nil, fmt.Errorf("store: downsampling series %s: %w", q.Path, err)
 	}

--- a/internal/store/datastreams_test.go
+++ b/internal/store/datastreams_test.go
@@ -375,6 +375,160 @@ func testDatastreams(t *testing.T, s *Store) {
 		}
 	})
 
+	t.Run("DownsampleLTTB", func(t *testing.T) {
+		if !s.HasToolkitLTTB() {
+			t.Skip("timescaledb_toolkit not installed; lttb path unavailable")
+		}
+		realm := mustCreateRealm(t, s)
+		device := mustRegisterDevice(t, s, realm.ID)
+		si := mustInstallInterface(t, s, realm.ID, allTypesDef)
+
+		// A flat series with one sharp spike. This is the whole reason lttb
+		// exists: time_bucket+avg would dilute the spike into its bucket's
+		// mean and the shape would be lost, whereas lttb selects the real
+		// sample. 60 points, spike of 1000 at index 30.
+		base := time.Date(2026, 1, 18, 12, 0, 0, 0, time.UTC)
+		const spikeIdx, spikeVal = 30, 1000.0
+		var batch DatastreamBatch
+		for i := range 60 {
+			v := 1.0
+			if i == spikeIdx {
+				v = spikeVal
+			}
+			batch.Individual = append(batch.Individual, IndividualRow{
+				RealmID: realm.ID, DeviceID: device, InterfaceID: si.ID,
+				EndpointID: si.Endpoints["/d"], Path: "/d",
+				TS: base.Add(time.Duration(i) * time.Minute), ReceptionTS: base,
+				ValueDouble: &v,
+			})
+		}
+		if err := s.AppendDatastreams(ctx, batch); err != nil {
+			t.Fatalf("AppendDatastreams: %v", err)
+		}
+		q := SeriesQuery{RealmID: realm.ID, DeviceID: device, InterfaceID: si.ID, Path: "/d"}
+
+		got, err := s.DownsampleLTTB(ctx, q, 8)
+		if err != nil {
+			t.Fatalf("DownsampleLTTB: %v", err)
+		}
+		if len(got) != 8 {
+			t.Fatalf("resolution 8: got %d points, want 8", len(got))
+		}
+		// Ascending by time, first and last samples preserved.
+		for i := 1; i < len(got); i++ {
+			if !got[i].Bucket.After(got[i-1].Bucket) {
+				t.Errorf("point %d not strictly after its predecessor: %v", i, got)
+			}
+		}
+		if !got[0].Bucket.Equal(base) {
+			t.Errorf("first point: got %v, want %v", got[0].Bucket, base)
+		}
+		if want := base.Add(59 * time.Minute); !got[len(got)-1].Bucket.Equal(want) {
+			t.Errorf("last point: got %v, want %v", got[len(got)-1].Bucket, want)
+		}
+		// The spike survives, at its own real timestamp and exact value. An
+		// averaging downsample cannot pass this: with 60 points reduced to 8
+		// the spike shares a bucket with flat neighbours and its mean is far
+		// below 1000.
+		spikeTS := base.Add(spikeIdx * time.Minute)
+		var found bool
+		for _, p := range got {
+			if p.Bucket.Equal(spikeTS) {
+				found = true
+				if p.Value != spikeVal {
+					t.Errorf("spike value: got %g, want %g", p.Value, spikeVal)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("lttb dropped the spike at %v: %v", spikeTS, got)
+		}
+		// Every returned value is a real sample, never an average.
+		for _, p := range got {
+			if p.Value != 1 && p.Value != spikeVal {
+				t.Errorf("point %v is not a real input sample", p)
+			}
+		}
+
+		// Descending reverses the output without changing which samples lttb
+		// picked: the aggregate sorts internally, so the order clause is
+		// applied outside it.
+		desc, err := s.DownsampleLTTB(ctx, SeriesQuery{
+			RealmID: realm.ID, DeviceID: device, InterfaceID: si.ID, Path: "/d", Descending: true,
+		}, 8)
+		if err != nil {
+			t.Fatalf("DownsampleLTTB descending: %v", err)
+		}
+		if len(desc) != len(got) {
+			t.Fatalf("descending: got %d points, want %d", len(desc), len(got))
+		}
+		for i := range desc {
+			if !desc[i].Bucket.Equal(got[len(got)-1-i].Bucket) {
+				t.Errorf("descending point %d: got %v, want %v", i, desc[i].Bucket, got[len(got)-1-i].Bucket)
+			}
+		}
+
+		// Limit trims the output but must not change the resolution lttb ran
+		// at — the first three points are the same as the unlimited run's.
+		lim, err := s.DownsampleLTTB(ctx, SeriesQuery{
+			RealmID: realm.ID, DeviceID: device, InterfaceID: si.ID, Path: "/d", Limit: 3,
+		}, 8)
+		if err != nil {
+			t.Fatalf("DownsampleLTTB limit: %v", err)
+		}
+		if len(lim) != 3 {
+			t.Fatalf("limit 3: got %d points", len(lim))
+		}
+		for i := range lim {
+			if !lim[i].Bucket.Equal(got[i].Bucket) || lim[i].Value != got[i].Value {
+				t.Errorf("limited point %d: got %v, want %v", i, lim[i], got[i])
+			}
+		}
+
+		// Integers coalesce into the value expression like the bucket path.
+		var intBatch DatastreamBatch
+		for i := range 10 {
+			v := int32(i)
+			intBatch.Individual = append(intBatch.Individual, IndividualRow{
+				RealmID: realm.ID, DeviceID: device, InterfaceID: si.ID,
+				EndpointID: si.Endpoints["/i"], Path: "/i",
+				TS: base.Add(time.Duration(i) * time.Minute), ReceptionTS: base,
+				ValueInteger: &v,
+			})
+		}
+		if err := s.AppendDatastreams(ctx, intBatch); err != nil {
+			t.Fatalf("AppendDatastreams integers: %v", err)
+		}
+		ints, err := s.DownsampleLTTB(ctx, SeriesQuery{
+			RealmID: realm.ID, DeviceID: device, InterfaceID: si.ID, Path: "/i",
+		}, 4)
+		if err != nil {
+			t.Fatalf("DownsampleLTTB integers: %v", err)
+		}
+		if len(ints) != 4 {
+			t.Errorf("integer lttb: got %d points, want 4", len(ints))
+		}
+
+		// Fewer samples than the resolution returns them all, not an error.
+		few, err := s.DownsampleLTTB(ctx, SeriesQuery{
+			RealmID: realm.ID, DeviceID: device, InterfaceID: si.ID, Path: "/i",
+		}, 50)
+		if err != nil {
+			t.Fatalf("DownsampleLTTB oversized resolution: %v", err)
+		}
+		if len(few) != 10 {
+			t.Errorf("oversized resolution: got %d points, want all 10", len(few))
+		}
+
+		// A resolution below 3 is refused by us, before Postgres raises
+		// "resolution must be greater than 2".
+		for _, n := range []int{-1, 0, 1, 2} {
+			if _, err := s.DownsampleLTTB(ctx, q, n); err == nil {
+				t.Errorf("resolution %d accepted", n)
+			}
+		}
+	})
+
 	t.Run("SeriesSpan", func(t *testing.T) {
 		realm := mustCreateRealm(t, s)
 		device := mustRegisterDevice(t, s, realm.ID)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -74,8 +74,8 @@ func testMigrations(t *testing.T, s *Store) {
 	if err := s.pool.QueryRow(ctx, `SELECT version, dirty FROM schema_migrations`).Scan(&version, &dirty); err != nil {
 		t.Fatalf("reading schema_migrations: %v", err)
 	}
-	if version != 6 || dirty {
-		t.Fatalf("schema_migrations: got version=%d dirty=%v, want version=6 dirty=false", version, dirty)
+	if version != 7 || dirty {
+		t.Fatalf("schema_migrations: got version=%d dirty=%v, want version=7 dirty=false", version, dirty)
 	}
 
 	hypertables := []string{"individual_datastreams", "object_datastreams"}
@@ -188,8 +188,8 @@ func testMigrationCycle(t *testing.T, s *Store) {
 	if err != nil {
 		t.Fatalf("reading version: %v", err)
 	}
-	if version != 6 || dirty {
-		t.Fatalf("after cycle: got version=%d dirty=%v, want version=6 dirty=false", version, dirty)
+	if version != 7 || dirty {
+		t.Fatalf("after cycle: got version=%d dirty=%v, want version=7 dirty=false", version, dirty)
 	}
 }
 

--- a/internal/testutil/pg.go
+++ b/internal/testutil/pg.go
@@ -17,7 +17,14 @@ import (
 const (
 	// TimescaleImage is the production-parity database image (docs/DESIGN.md §5.4):
 	// tests run against the exact image the docker-compose deployment ships.
-	TimescaleImage = "timescale/timescaledb:latest-pg16"
+	//
+	// The -ha variant, and that is load-bearing rather than incidental: it is
+	// the only published image carrying timescaledb_toolkit, so on the plain
+	// image Store.hasToolkit is false and every lttb() test silently skips.
+	// A downsampling path that no test run can reach is the "green gate that
+	// means nothing" this pin exists to prevent — keep it in lockstep with
+	// docker-compose.yml.
+	TimescaleImage = "timescale/timescaledb-ha:pg16"
 
 	// EnvTestDSN names the env var that, when set, short-circuits container
 	// startup and connects to an already-running database instead (e.g.

--- a/migrations/000007_toolkit.down.sql
+++ b/migrations/000007_toolkit.down.sql
@@ -1,0 +1,4 @@
+-- 000007 down: drop the toolkit if this migration installed it. Safe when the
+-- extension was never created, and the lttb path degrades to time_bucket+avg
+-- rather than failing.
+DROP EXTENSION IF EXISTS timescaledb_toolkit;

--- a/migrations/000007_toolkit.up.sql
+++ b/migrations/000007_toolkit.up.sql
@@ -1,0 +1,16 @@
+-- 000007: enable timescaledb_toolkit where the server actually ships it.
+--
+-- Deliberately conditional rather than a plain CREATE EXTENSION. The toolkit
+-- is an *optional* capability: Store.probeToolkit reads pg_extension at
+-- startup and Downsample falls back to time_bucket+avg when it is absent
+-- (docs/DESIGN.md §2.5), and that fallback is a load-bearing invariant — a
+-- deployment on a server without the toolkit must still migrate cleanly.
+-- Creating it unconditionally would turn an optional path into a hard
+-- requirement for every operator.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'timescaledb_toolkit') THEN
+        CREATE EXTENSION IF NOT EXISTS timescaledb_toolkit;
+    END IF;
+END
+$$;


### PR DESCRIPTION
## Summary
- `Store.DownsampleLTTB` uses `timescaledb_toolkit`'s `lttb()` (Largest-Triangle-Three-Buckets) to reduce a series to real samples that preserve its visual shape, instead of averaging spikes away; `Store.Downsample` (time_bucket+avg) is untouched and stays the always-available fallback.
- `internal/appengine/data.go` picks between them: `lttb` when `Store.HasToolkitLTTB()` and the requested point count is ≥ 3 (lttb rejects a smaller resolution outright), the bucket path otherwise — so `downsample_to=2` keeps working everywhere.
- Dev compose and both CI paths (service containers *and* the testcontainers pin in `internal/testutil/pg.go`) move to `timescale/timescaledb-ha:pg16`, the only published image carrying the toolkit, with a new volume name (`pgdata_ha`) since the image's data directory and container user both change.
- Migration `000007_toolkit` creates the extension only where `pg_available_extensions` lists it, so a toolkit-less deployment still migrates cleanly.

This closes the `lttb` extension point named in `docs/ROADMAP.md` §0.1 rule 3 (`docs/DESIGN.md` §2.5).

**Note on landing history:** this branch was originally developed and its acceptance criteria verified back on 2026-07-26/27, but no PR was ever opened for it — a gap only noticed when resuming this branch's work. It has now been rebased onto current `main` (no conflicts) and re-verified in full below before opening this PR.

## Test plan
- [x] `gofmt -l` clean on all changed files
- [x] `go build ./...`
- [x] `go vet ./internal/store/... ./internal/appengine/...`
- [x] `go test -race ./...` (T1, full repo)
- [x] T2 against `timescaledb-ha:pg16` (toolkit present): `TestStore/Datastreams/DownsampleLTTB` passes for real (not skipped)
- [x] T2 against toolkit-less `timescaledb:latest-pg16` (fallback): migration 000007 applies cleanly, `DownsampleLTTB` self-skips with a logged reason, all other `Datastreams` subtests pass