### PR TITLE
fix: land blocked mule issues #14 #21 #22 #24 #27

### DIFF
--- a/cmd/astrate/main.go
+++ b/cmd/astrate/main.go
@@ -309,7 +309,10 @@ func mountAPIs(cfg config.Config, st *store.Store, e *engine.Engine, b *broker.B
 	}
 	hkSvc := housekeeping.NewService(st, sealer, b, log)
 	housekeeping.NewAPI(hkSvc, mw, hkKeys).Mount(mux)
-	realm.NewAPI(realm.NewService(st, e, log).WithDisconnecter(b), mw).Mount(mux)
+	realmSvc := realm.NewService(st, e, log).WithDisconnecter(b)
+	realmSvc.OnDeletionStart = e.HandleDeviceDeletionStarted
+	realmSvc.OnDeletionFinish = e.HandleDeviceDeletionFinished
+	realm.NewAPI(realmSvc, mw).Mount(mux)
 	appengine.NewAPI(appengine.NewService(st, e, log), mw).Mount(mux)
 	apstream.NewAPI(e.Bus(), mw).Mount(mux)
 	// Phoenix Channels socket (phoenix.js V2), alongside the Astrate-native

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -99,6 +99,7 @@ choices are pinned here so Phase 3 never has to re-litigate them.
 | TOML config | `github.com/BurntSushi/toml` | §5.1 |
 | Test containers | `github.com/testcontainers/testcontainers-go` (+ postgres module), image `timescale/timescaledb:latest-pg16` | §5.4 parity with production image |
 | Test MQTT client | `github.com/eclipse/paho.mqtt.golang` (test-only) | Same client family the official Go SDK uses |
+| Mustache templates | `github.com/cbroglie/mustache` | Pure Go, zero transitive deps; renders `template_type: "mustache"` trigger HTTP action bodies (`060-triggers.md:516-543`) — additive, internal to action-dispatch, doesn't touch the wire protocol or SDK surface (Giulio, 2026-07-27) |
 
 ### 1.2 Files
 

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 )
 
 require (
+	github.com/cbroglie/mustache v1.4.0
 	github.com/nats-io/nats.go v1.52.0
 	github.com/testcontainers/testcontainers-go/modules/nats v0.43.0
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/cbroglie/mustache v1.4.0 h1:Azg0dVhxTml5me+7PsZ7WPrQq1Gkf3WApcHMjMprYoU=
+github.com/cbroglie/mustache v1.4.0/go.mod h1:SS1FTIghy0sjse4DUVGV1k/40B1qE1XkD9DtDsHo9iM=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/internal/broker/aclhook.go
+++ b/internal/broker/aclhook.go
@@ -62,6 +62,10 @@ func checkACL(base, topic string, write bool, ownership ownershipFn) bool {
 		if rest == "capabilities" || rest == "control/emptyCache" || rest == "control/producer/properties" {
 			return true
 		}
+		// control/keyAgreement (080-mqtt-v1-protocol.md:172-176) is deliberately
+		// unsupported: upstream itself documents the handshake as "reserved and
+		// routed correctly, but not yet implemented", so falling through to the
+		// deny path below matches upstream's own status rather than being a gap.
 		iface, path, found := strings.Cut(rest, "/")
 		if !found || path == "" { // data topics always carry a path (§3.3)
 			return false

--- a/internal/broker/aclhook_test.go
+++ b/internal/broker/aclhook_test.go
@@ -50,6 +50,7 @@ func TestCheckACLMatrix(t *testing.T) {
 		{"pub interface with empty path", base + "/com.ex.DeviceData/", true, false},
 		{"pub control consumer properties", base + "/control/consumer/properties", true, false},
 		{"pub control unknown", base + "/control/selfDestruct", true, false},
+		{"pub control keyAgreement", base + "/control/keyAgreement", true, false},
 		{"pub control prefix only", base + "/control", true, false},
 		{"pub bare realm", "test", true, false},
 		{"pub empty topic", "", true, false},

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -300,6 +300,40 @@ func (e *Engine) HandleDeviceRegistered(realmName string, hwID string, at time.T
 	})
 }
 
+// HandleDeviceDeletionStarted is called by the realm service immediately
+// before a synchronous device delete. It fires device_deletion_started
+// triggers and publishes on the live bus (issue #21; upstream wraps async
+// deletion with the same pair of events).
+func (e *Engine) HandleDeviceDeletionStarted(realmName string, hwID string, at time.Time) {
+	e.handleDeviceDeletion(realmName, hwID, at,
+		triggers.OnDeviceDeletionStarted, stream.KindDeviceDeletionStarted,
+		triggers.NewDeviceDeletionStartedEvent())
+}
+
+// HandleDeviceDeletionFinished is called by the realm service immediately
+// after a synchronous device delete completes (success or failure after the
+// delete was attempted).
+func (e *Engine) HandleDeviceDeletionFinished(realmName string, hwID string, at time.Time) {
+	e.handleDeviceDeletion(realmName, hwID, at,
+		triggers.OnDeviceDeletionFinished, stream.KindDeviceDeletionFinished,
+		triggers.NewDeviceDeletionFinishedEvent())
+}
+
+func (e *Engine) handleDeviceDeletion(realmName, hwID string, at time.Time, on, kind string, body any) {
+	rs := e.schemas.realm(realmName)
+	if rs == nil {
+		return
+	}
+	id, err := deviceid.Parse(hwID)
+	if err != nil {
+		return
+	}
+	e.fireDevice(rs, id, at, triggers.DeviceEvent{DeviceID: hwID, On: on}, body)
+	e.bus.Publish(stream.Event{
+		Kind: kind, Realm: rs.name, DeviceID: hwID, Timestamp: at,
+	})
+}
+
 // eventValue renders a decoded payload value into its canonical
 // JSON-friendly form for trigger events and the live bus; nil stays nil
 // (property unset renders as JSON null, upstream parity).

--- a/internal/engine/stream/bus.go
+++ b/internal/engine/stream/bus.go
@@ -24,6 +24,12 @@ const (
 	KindDeviceConnected = "device_connected"
 	// KindDeviceDisconnected is a device disconnection.
 	KindDeviceDisconnected = "device_disconnected"
+	// KindDeviceDeletionStarted is emitted immediately before a synchronous
+	// device delete (upstream fires it at the start of async deletion).
+	KindDeviceDeletionStarted = "device_deletion_started"
+	// KindDeviceDeletionFinished is emitted immediately after a synchronous
+	// device delete (upstream fires it when async deletion completes).
+	KindDeviceDeletionFinished = "device_deletion_finished"
 	// KindDeviceError is a rejected device message (docs/DESIGN.md §2.6
 	// "failures are never silent"). Unlike the trigger path, it is published
 	// whether or not the realm declares any trigger.

--- a/internal/engine/triggers/actions.go
+++ b/internal/engine/triggers/actions.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cbroglie/mustache"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -33,6 +34,13 @@ type Action struct {
 	// Custom is the raw action object of a non-HTTP action, delivered
 	// through the Forwarder extension point; nil for HTTP actions.
 	Custom json.RawMessage
+	// Template is the Mustache body template (upstream "template"), set
+	// only when TemplateType == "mustache".
+	Template string
+	// TemplateType is the upstream "template_type" field. Only "mustache"
+	// is rendered; any other non-empty value is accepted but ignored (the
+	// default JSON envelope is sent), same as before this field existed.
+	TemplateType string
 }
 
 // httpAction is the upstream HTTP action JSON shape.
@@ -53,8 +61,8 @@ var httpMethods = map[string]bool{
 }
 
 // parseAction validates one action object. It returns the parsed action
-// plus the list of accepted-but-not-evaluated features (Mustache payload
-// templates: the default JSON envelope is sent instead).
+// plus the list of accepted-but-not-evaluated features (non-mustache
+// template_type values: the default JSON envelope is sent instead).
 func parseAction(raw json.RawMessage) (*Action, []string, error) {
 	if len(raw) == 0 {
 		return nil, nil, fmt.Errorf("missing action")
@@ -65,8 +73,8 @@ func parseAction(raw json.RawMessage) (*Action, []string, error) {
 	}
 
 	var unsupported []string
-	if h.Template != "" || h.TemplateType != "" {
-		unsupported = append(unsupported, "mustache payload template (default JSON envelope sent)")
+	if h.TemplateType != "" && h.TemplateType != "mustache" {
+		unsupported = append(unsupported, fmt.Sprintf("template_type %q (default JSON envelope sent)", h.TemplateType))
 	}
 
 	switch {
@@ -74,6 +82,7 @@ func parseAction(raw json.RawMessage) (*Action, []string, error) {
 		return &Action{
 			Method: http.MethodPost, URL: h.HTTPPostURL,
 			StaticHeaders: h.HTTPStaticHeaders, IgnoreSSLErrors: h.IgnoreSSLErrors,
+			Template: h.Template, TemplateType: h.TemplateType,
 		}, unsupported, nil
 	case h.HTTPURL != "":
 		if !httpMethods[h.HTTPMethod] {
@@ -84,6 +93,7 @@ func parseAction(raw json.RawMessage) (*Action, []string, error) {
 			// HTTP methods are case-sensitive uppercase tokens.
 			Method: strings.ToUpper(h.HTTPMethod), URL: h.HTTPURL,
 			StaticHeaders: h.HTTPStaticHeaders, IgnoreSSLErrors: h.IgnoreSSLErrors,
+			Template: h.Template, TemplateType: h.TemplateType,
 		}, unsupported, nil
 	default:
 		// Not an HTTP action (e.g. upstream AMQP): keep it verbatim for the
@@ -362,11 +372,49 @@ func (x *Executor) deliver(d Delivery) {
 		return
 	}
 
+	if d.Trigger.Action.TemplateType == "mustache" {
+		if rendered, err := renderMustache(d.Trigger.Action.Template, d.Realm, d.Event); err != nil {
+			x.log.Warn("mustache action template failed to render; sending default envelope",
+				"realm", d.Realm, "trigger", d.Trigger.Name, "err", err)
+		} else {
+			body = rendered
+		}
+	}
+
 	if d.Trigger.Action.Custom != nil {
 		x.forward(d, body)
 		return
 	}
 	x.webhook(d, body)
+}
+
+// renderMustache renders a "template_type": "mustache" action body
+// (060-triggers.md:516-543) with the realm/device/trigger/event fields
+// upstream documents. event fields (interface, path, value, ...) are
+// flattened in alongside the envelope fields rather than nested, matching
+// upstream's flat template namespace.
+func renderMustache(template, realm string, event SimpleEvent) ([]byte, error) {
+	ctx := map[string]any{
+		"realm":        realm,
+		"device_id":    event.DeviceID,
+		"timestamp":    event.Timestamp.UTC().Format(EventTimeLayout),
+		"trigger_name": event.TriggerName,
+	}
+	if raw, err := json.Marshal(event.Event); err == nil {
+		var fields map[string]any
+		if json.Unmarshal(raw, &fields) == nil {
+			for k, v := range fields {
+				ctx[k] = v
+			}
+		}
+	}
+	// forceRaw: HTML-escaping {{var}} would mangle JSON/text bodies, which is
+	// what these templates almost always render.
+	rendered, err := mustache.RenderRaw(template, true, ctx)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(rendered), nil
 }
 
 // forward hands a non-HTTP action to the Forwarder extension point.

--- a/internal/engine/triggers/actions_test.go
+++ b/internal/engine/triggers/actions_test.go
@@ -129,13 +129,13 @@ func TestParseAction(t *testing.T) {
 		}
 	})
 
-	t.Run("mustache template noted as unsupported, default envelope still sent", func(t *testing.T) {
+	t.Run("mustache template parsed and not marked unsupported", func(t *testing.T) {
 		a, unsupported, err := parseAction([]byte(
 			`{"http_url":"https://x","http_method":"post","template":"{{ value }}","template_type":"mustache"}`))
 		if err != nil {
 			t.Fatal(err)
 		}
-		if a.URL == "" || len(unsupported) != 1 {
+		if a.URL == "" || a.Template != "{{ value }}" || len(unsupported) != 0 {
 			t.Errorf("action=%+v unsupported=%v", a, unsupported)
 		}
 	})
@@ -196,6 +196,73 @@ func TestWebhookDelivered(t *testing.T) {
 	wantBody, _ := json.Marshal(d.Event)
 	if string(gotBody) != string(wantBody) {
 		t.Errorf("body = %s, want %s", gotBody, wantBody)
+	}
+}
+
+// TestWebhookMustacheTemplateRendered: a mustache action renders the body
+// from realm/device/trigger/event fields instead of the default envelope.
+func TestWebhookMustacheTemplateRendered(t *testing.T) {
+	var gotBody []byte
+	done := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusNoContent)
+		close(done)
+	}))
+	defer srv.Close()
+
+	x := newTestExecutor(t, ExecutorConfig{Workers: 1})
+	d := testDelivery(&Action{
+		Method: http.MethodPost, URL: srv.URL,
+		Template:     "{{realm}}/{{device_id}}/{{interface}}{{path}}={{value}}",
+		TemplateType: "mustache",
+	})
+	x.Enqueue(d)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("webhook never received")
+	}
+	eventually(t, 1, func() float64 { return outcome(x, outcomeDelivered) })
+
+	const want = "testrealm/f0VMRgIBAQAAAAAAAAAAAA/com.ex.Sensors/v=1"
+	if string(gotBody) != want {
+		t.Errorf("body = %s, want %s", gotBody, want)
+	}
+}
+
+// TestWebhookMustacheTemplateMalformedFallsBack: an unclosed tag fails to
+// render and the delivery falls back to the default JSON envelope rather
+// than crashing the dispatcher.
+func TestWebhookMustacheTemplateMalformedFallsBack(t *testing.T) {
+	var gotBody []byte
+	done := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusNoContent)
+		close(done)
+	}))
+	defer srv.Close()
+
+	x := newTestExecutor(t, ExecutorConfig{Workers: 1})
+	d := testDelivery(&Action{
+		Method: http.MethodPost, URL: srv.URL,
+		Template:     "{{unclosed",
+		TemplateType: "mustache",
+	})
+	x.Enqueue(d)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("webhook never received")
+	}
+	eventually(t, 1, func() float64 { return outcome(x, outcomeDelivered) })
+
+	wantBody, _ := json.Marshal(d.Event)
+	if string(gotBody) != string(wantBody) {
+		t.Errorf("body = %s, want default envelope %s", gotBody, wantBody)
 	}
 }
 

--- a/internal/engine/triggers/events.go
+++ b/internal/engine/triggers/events.go
@@ -111,6 +111,28 @@ func NewDeviceDisconnectedEvent() DeviceDisconnectedEvent {
 	return DeviceDisconnectedEvent{Type: OnDeviceDisconnected}
 }
 
+// DeviceDeletionStartedEvent is the device_deletion_started event body.
+type DeviceDeletionStartedEvent struct {
+	// Type is always "device_deletion_started".
+	Type string `json:"type"`
+}
+
+// NewDeviceDeletionStartedEvent builds a device_deletion_started event body.
+func NewDeviceDeletionStartedEvent() DeviceDeletionStartedEvent {
+	return DeviceDeletionStartedEvent{Type: OnDeviceDeletionStarted}
+}
+
+// DeviceDeletionFinishedEvent is the device_deletion_finished event body.
+type DeviceDeletionFinishedEvent struct {
+	// Type is always "device_deletion_finished".
+	Type string `json:"type"`
+}
+
+// NewDeviceDeletionFinishedEvent builds a device_deletion_finished event body.
+func NewDeviceDeletionFinishedEvent() DeviceDeletionFinishedEvent {
+	return DeviceDeletionFinishedEvent{Type: OnDeviceDeletionFinished}
+}
+
 // DeviceErrorEvent is the device_error event body.
 type DeviceErrorEvent struct {
 	// Type is always "device_error".

--- a/internal/engine/triggers/events_test.go
+++ b/internal/engine/triggers/events_test.go
@@ -38,6 +38,8 @@ func TestEventGoldens(t *testing.T) {
 		{name: "device_connected.json", body: NewDeviceConnectedEvent("203.0.113.89")},
 		{name: "device_registered.json", body: NewDeviceRegisteredEvent()},
 		{name: "device_disconnected.json", body: NewDeviceDisconnectedEvent()},
+		{name: "device_deletion_started.json", body: NewDeviceDeletionStartedEvent()},
+		{name: "device_deletion_finished.json", body: NewDeviceDeletionFinishedEvent()},
 		{name: "device_error.json", body: NewDeviceErrorEvent(
 			"interface_not_in_introspection", map[string]string{"detail": "no introspected interface matches x"})},
 		{name: "device_error_no_metadata.json", body: NewDeviceErrorEvent("empty_cache_error", nil)},

--- a/internal/engine/triggers/match.go
+++ b/internal/engine/triggers/match.go
@@ -46,6 +46,12 @@ const (
 	OnDeviceConnected = "device_connected"
 	// OnDeviceDisconnected fires when a device connection ends.
 	OnDeviceDisconnected = "device_disconnected"
+	// OnDeviceDeletionStarted fires immediately before a device is deleted
+	// (upstream: start of async deletion; Astrate: before the sync delete).
+	OnDeviceDeletionStarted = "device_deletion_started"
+	// OnDeviceDeletionFinished fires immediately after a device is deleted
+	// (upstream: end of async deletion; Astrate: after the sync delete).
+	OnDeviceDeletionFinished = "device_deletion_finished"
 	// OnDeviceEmptyCacheReceived fires on control/emptyCache (accepted, not
 	// evaluated in v1: upstream defines no SimpleEvent variant for it).
 	OnDeviceEmptyCacheReceived = "device_empty_cache_received"
@@ -87,6 +93,8 @@ var deviceOns = map[string]bool{
 	OnDeviceRegistered:         true,
 	OnDeviceConnected:          true,
 	OnDeviceDisconnected:       true,
+	OnDeviceDeletionStarted:    true,
+	OnDeviceDeletionFinished:   true,
 	OnDeviceEmptyCacheReceived: false,
 	OnDeviceError:              true,
 	OnIncomingIntrospection:    true,

--- a/internal/engine/triggers/match_test.go
+++ b/internal/engine/triggers/match_test.go
@@ -242,6 +242,21 @@ func TestMatchDevice(t *testing.T) {
 			ev: DeviceEvent{DeviceID: "x", On: OnDeviceConnected}, want: true},
 		{name: "connected ignores disconnects", trigger: connected,
 			ev: DeviceEvent{DeviceID: "x", On: OnDeviceDisconnected}, want: false},
+		{name: "deletion_started matches its on", trigger: compile(t, `{
+			"name": "del", "action": {"http_post_url": "https://x"},
+			"simple_triggers": [{"type": "device_trigger", "on": "device_deletion_started"}]
+		}`),
+			ev: DeviceEvent{DeviceID: "x", On: OnDeviceDeletionStarted}, want: true},
+		{name: "deletion_finished matches its on", trigger: compile(t, `{
+			"name": "del", "action": {"http_post_url": "https://x"},
+			"simple_triggers": [{"type": "device_trigger", "on": "device_deletion_finished"}]
+		}`),
+			ev: DeviceEvent{DeviceID: "x", On: OnDeviceDeletionFinished}, want: true},
+		{name: "deletion_started ignores finished", trigger: compile(t, `{
+			"name": "del", "action": {"http_post_url": "https://x"},
+			"simple_triggers": [{"type": "device_trigger", "on": "device_deletion_started"}]
+		}`),
+			ev: DeviceEvent{DeviceID: "x", On: OnDeviceDeletionFinished}, want: false},
 		{name: "device filter matches", trigger: oneDevice,
 			ev: DeviceEvent{DeviceID: "f0VMRgIBAQAAAAAAAAAAAA", On: OnDeviceDisconnected}, want: true},
 		{name: "device filter rejects others", trigger: oneDevice,
@@ -394,8 +409,20 @@ func TestCompileActions(t *testing.T) {
 			"template_type": "mustache", "template": "{{ value }}"},
 		"simple_triggers": [{"type": "device_trigger", "on": "device_connected"}]
 	}`)
-	if len(templated.Unsupported) == 0 {
-		t.Error("mustache template accepted silently")
+	if len(templated.Unsupported) != 0 {
+		t.Errorf("mustache template should render, not be marked unsupported: %v", templated.Unsupported)
+	}
+	if templated.Action.Template != "{{ value }}" {
+		t.Errorf("template not carried through: %+v", templated.Action)
+	}
+
+	unknownTemplate := compile(t, `{
+		"action": {"http_url": "https://example.com", "http_method": "post",
+			"template_type": "jinja2", "template": "{{ value }}"},
+		"simple_triggers": [{"type": "device_trigger", "on": "device_connected"}]
+	}`)
+	if len(unknownTemplate.Unsupported) == 0 {
+		t.Error("non-mustache template_type accepted silently")
 	}
 
 	headers := compile(t, `{

--- a/internal/engine/triggers/testdata/device_deletion_finished.json
+++ b/internal/engine/triggers/testdata/device_deletion_finished.json
@@ -1,0 +1,1 @@
+{"timestamp":"2026-06-12T10:00:00.123Z","device_id":"f0VMRgIBAQAAAAAAAAAAAA","event":{"type":"device_deletion_finished"},"trigger_name":"example_trigger"}

--- a/internal/engine/triggers/testdata/device_deletion_started.json
+++ b/internal/engine/triggers/testdata/device_deletion_started.json
@@ -1,0 +1,1 @@
+{"timestamp":"2026-06-12T10:00:00.123Z","device_id":"f0VMRgIBAQAAAAAAAAAAAA","event":{"type":"device_deletion_started"},"trigger_name":"example_trigger"}

--- a/internal/flow/blocks/astartesource/source.go
+++ b/internal/flow/blocks/astartesource/source.go
@@ -1,0 +1,133 @@
+// Package astartesource implements the AstarteSource Flow block (issue #27,
+// astarte_flow parity): a Source that subscribes to Astrate's existing live
+// event bus (internal/engine/stream) and converts device events into
+// FlowMessages, connecting device ingestion to operator-defined pipelines.
+package astartesource
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/astrate-platform/astrate/internal/engine/stream"
+	"github.com/astrate-platform/astrate/internal/flow"
+)
+
+// Config selects which events a Source consumes.
+type Config struct {
+	// Realm is the tenant to subscribe to (required).
+	Realm string
+	// Interface, when set, keeps only that interface's data events;
+	// lifecycle events (no interface) are dropped when this is set.
+	Interface string
+	// Path, when set, keeps only data events whose path has this prefix.
+	Path string
+}
+
+// Source is a Flow Source block backed by a stream.Bus subscription. The
+// zero value is not usable; construct with New.
+type Source struct {
+	cfg    Config
+	ch     <-chan stream.Event
+	cancel func()
+}
+
+// New subscribes to bus for cfg.Realm/cfg.Interface and returns a Source
+// ready to be used as a flow.Block. Call Stop when the flow using it stops,
+// to release the subscription.
+func New(bus *stream.Bus, cfg Config) *Source {
+	ch, cancel := bus.Subscribe(cfg.Realm, stream.Filter{Interface: cfg.Interface}, 0)
+	return &Source{cfg: cfg, ch: ch, cancel: cancel}
+}
+
+// Name implements flow.Block.
+func (s *Source) Name() string { return "astarte_source" }
+
+// Process implements flow.Block as a Source: it drains every event
+// currently buffered on the subscription (non-blocking) and converts each
+// to a FlowMessage. Called repeatedly by the router's polling loop.
+func (s *Source) Process(_ *flow.FlowMessage) ([]*flow.FlowMessage, error) {
+	var out []*flow.FlowMessage
+	for {
+		select {
+		case ev, ok := <-s.ch:
+			if !ok {
+				return out, nil
+			}
+			if s.cfg.Path != "" && !strings.HasPrefix(ev.Path, s.cfg.Path) {
+				continue
+			}
+			out = append(out, toFlowMessage(&ev))
+		default:
+			return out, nil
+		}
+	}
+}
+
+// Stop unsubscribes from the bus. Safe to call once; the underlying channel
+// is closed by the bus, after which Process returns cleanly with no events.
+func (s *Source) Stop() {
+	s.cancel()
+}
+
+// toFlowMessage converts one stream.Event to the upstream FlowMessage shape
+// (astarte_flow/message/v0.1): key "<realm>/<device_id>", data/subtype
+// events map from Event.Value; lifecycle events (no Interface/Path) carry
+// their kind and metadata instead.
+func toFlowMessage(ev *stream.Event) *flow.FlowMessage {
+	msg := &flow.FlowMessage{
+		Key:       ev.Realm + "/" + ev.DeviceID,
+		Timestamp: ev.Timestamp.UnixMicro(),
+		Metadata: map[string]string{
+			"kind":      ev.Kind,
+			"interface": ev.Interface,
+			"path":      ev.Path,
+		},
+	}
+	setValue(msg, ev.Value)
+	return msg
+}
+
+// setValue maps a stream.Event's JSON-friendly Value into the message's
+// typed Data/Type, defaulting to a string rendering for anything that
+// isn't one of the wire-representable scalar kinds.
+func setValue(msg *flow.FlowMessage, v any) {
+	switch val := v.(type) {
+	case nil:
+		msg.Type = flow.TypeString
+		msg.Data = ""
+	case bool:
+		msg.Type = flow.TypeBoolean
+		msg.Data = val
+	case float64:
+		msg.Type = flow.TypeReal
+		msg.Data = val
+	case int64:
+		msg.Type = flow.TypeInteger
+		msg.Data = val
+	case string:
+		msg.Type = flow.TypeString
+		msg.Data = val
+	case map[string]any:
+		msg.Type = flow.TypeMap
+		msg.FieldTypes = make(map[string]flow.DataType, len(val))
+		data := make(map[string]any, len(val))
+		for k, fv := range val {
+			switch fval := fv.(type) {
+			case bool:
+				msg.FieldTypes[k] = flow.TypeBoolean
+				data[k] = fval
+			case float64:
+				msg.FieldTypes[k] = flow.TypeReal
+				data[k] = fval
+			default:
+				msg.FieldTypes[k] = flow.TypeString
+				data[k] = fmt.Sprint(fval)
+			}
+		}
+		msg.Data = data
+	default:
+		msg.Type = flow.TypeString
+		msg.Data = strconv.Quote(fmt.Sprint(val))
+	}
+}

--- a/internal/flow/blocks/astartesource/source_test.go
+++ b/internal/flow/blocks/astartesource/source_test.go
@@ -1,0 +1,101 @@
+package astartesource
+
+import (
+	"testing"
+	"time"
+
+	"github.com/astrate-platform/astrate/internal/engine/stream"
+	"github.com/astrate-platform/astrate/internal/flow"
+)
+
+func TestSourceIngestsAndConverts(t *testing.T) {
+	bus := stream.New(nil)
+	src := New(bus, Config{Realm: "test"})
+	defer src.Stop()
+
+	ts := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	bus.Publish(stream.Event{
+		Kind: stream.KindIncomingData, Realm: "test", DeviceID: "dev1",
+		Interface: "com.ex.Sensors", Path: "/v", Value: 1.5, Timestamp: ts,
+	})
+
+	var got []*flow.FlowMessage
+	deadline := time.Now().Add(2 * time.Second)
+	for len(got) == 0 && time.Now().Before(deadline) {
+		msgs, err := src.Process(nil)
+		if err != nil {
+			t.Fatalf("Process: %v", err)
+		}
+		got = append(got, msgs...)
+		if len(got) == 0 {
+			time.Sleep(time.Millisecond)
+		}
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d messages, want 1", len(got))
+	}
+	m := got[0]
+	if m.Key != "test/dev1" {
+		t.Errorf("Key = %q, want test/dev1", m.Key)
+	}
+	if m.Type != flow.TypeReal || m.Data.(float64) != 1.5 {
+		t.Errorf("Type/Data = %v/%v, want TypeReal/1.5", m.Type, m.Data)
+	}
+	if m.Timestamp != ts.UnixMicro() {
+		t.Errorf("Timestamp = %d, want %d", m.Timestamp, ts.UnixMicro())
+	}
+}
+
+func TestSourceRealmAndInterfaceFilter(t *testing.T) {
+	bus := stream.New(nil)
+	src := New(bus, Config{Realm: "test", Interface: "com.ex.Sensors"})
+	defer src.Stop()
+
+	bus.Publish(stream.Event{Kind: stream.KindIncomingData, Realm: "other", DeviceID: "dev1", Interface: "com.ex.Sensors", Value: 1.0})
+	bus.Publish(stream.Event{Kind: stream.KindIncomingData, Realm: "test", DeviceID: "dev1", Interface: "com.ex.Other", Value: 2.0})
+	bus.Publish(stream.Event{Kind: stream.KindIncomingData, Realm: "test", DeviceID: "dev1", Interface: "com.ex.Sensors", Value: 3.0})
+
+	time.Sleep(20 * time.Millisecond)
+	msgs, err := src.Process(nil)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if len(msgs) != 1 || msgs[0].Data.(float64) != 3.0 {
+		t.Fatalf("msgs = %+v, want one message with Data 3.0", msgs)
+	}
+}
+
+func TestSourcePathFilter(t *testing.T) {
+	bus := stream.New(nil)
+	src := New(bus, Config{Realm: "test", Path: "/keep"})
+	defer src.Stop()
+
+	bus.Publish(stream.Event{Kind: stream.KindIncomingData, Realm: "test", DeviceID: "d", Path: "/drop/x", Value: 1.0})
+	bus.Publish(stream.Event{Kind: stream.KindIncomingData, Realm: "test", DeviceID: "d", Path: "/keep/x", Value: 2.0})
+
+	time.Sleep(20 * time.Millisecond)
+	msgs, err := src.Process(nil)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if len(msgs) != 1 || msgs[0].Data.(float64) != 2.0 {
+		t.Fatalf("msgs = %+v, want one message with Data 2.0", msgs)
+	}
+}
+
+func TestSourceStopUnsubscribesCleanly(t *testing.T) {
+	bus := stream.New(nil)
+	src := New(bus, Config{Realm: "test"})
+	if bus.Subscribers() != 1 {
+		t.Fatalf("Subscribers = %d, want 1", bus.Subscribers())
+	}
+	src.Stop()
+	if bus.Subscribers() != 0 {
+		t.Fatalf("Subscribers after Stop = %d, want 0", bus.Subscribers())
+	}
+	// Process on a stopped source must return cleanly, not block or panic.
+	msgs, err := src.Process(nil)
+	if err != nil || msgs != nil {
+		t.Errorf("Process after Stop = %v, %v, want nil, nil", msgs, err)
+	}
+}

--- a/internal/realm/dashboard_compat_test.go
+++ b/internal/realm/dashboard_compat_test.go
@@ -86,6 +86,16 @@ func TestDashboardCompat(t *testing.T) {
 		disc := &fakeDisconnecter{}
 		r.svc.WithDisconnecter(disc)
 
+		// Issue #21: deletion lifecycle events fire back-to-back around the
+		// synchronous store delete (started before, finished after).
+		var lifecycle []string
+		r.svc.OnDeletionStart = func(realmName, deviceID string, _ time.Time) {
+			lifecycle = append(lifecycle, "start:"+realmName+"/"+deviceID)
+		}
+		r.svc.OnDeletionFinish = func(realmName, deviceID string, _ time.Time) {
+			lifecycle = append(lifecycle, "finish:"+realmName+"/"+deviceID)
+		}
+
 		dev, err := deviceid.Random()
 		if err != nil {
 			t.Fatal(err)
@@ -115,6 +125,13 @@ func TestDashboardCompat(t *testing.T) {
 		if len(disc.kicked) != 1 || disc.kicked[0] != r.realm+"/"+dev.String() {
 			t.Errorf("kick calls = %v", disc.kicked)
 		}
+		wantLife := []string{
+			"start:" + r.realm + "/" + dev.String(),
+			"finish:" + r.realm + "/" + dev.String(),
+		}
+		if len(lifecycle) != 2 || lifecycle[0] != wantLife[0] || lifecycle[1] != wantLife[1] {
+			t.Errorf("deletion lifecycle = %v, want %v", lifecycle, wantLife)
+		}
 		if _, err := r.st.GetDevice(ctx, r.realmID, dev); err == nil {
 			t.Error("device row survived the delete")
 		}
@@ -123,6 +140,8 @@ func TestDashboardCompat(t *testing.T) {
 			t.Errorf("data survived the delete: %d rows, err %v", len(rows), err)
 		}
 		// Unknown and malformed IDs → the upstream device 404 envelope.
+		// Not-found delete still emits start+finish (lifecycle always closes).
+		lifecycle = nil
 		for _, path := range []string{"/devices/" + dev.String(), "/devices/not-an-id"} {
 			rec := r.req(t, http.MethodDelete, path, "", r.rmaToken)
 			if rec.Code != http.StatusNotFound {
@@ -131,6 +150,11 @@ func TestDashboardCompat(t *testing.T) {
 			if body := rec.Body.String(); body != `{"errors":{"detail":"Device not found"}}` {
 				t.Errorf("DELETE %s body = %s", path, body)
 			}
+		}
+		// Second delete of the known (now gone) device: parse OK → start+finish.
+		// Malformed ID never reaches the emit path.
+		if len(lifecycle) != 2 || lifecycle[0] != wantLife[0] || lifecycle[1] != wantLife[1] {
+			t.Errorf("not-found deletion lifecycle = %v, want %v", lifecycle, wantLife)
 		}
 	})
 }

--- a/internal/realm/service.go
+++ b/internal/realm/service.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"time"
 
 	"github.com/astrate-platform/astrate/internal/engine/triggers"
 	"github.com/astrate-platform/astrate/internal/store"
@@ -45,12 +46,20 @@ type Disconnecter interface {
 	DisconnectDevice(realm string, id deviceid.ID)
 }
 
+// OnDeletionFunc is called around a synchronous device delete so the engine
+// can emit device_deletion_started / device_deletion_finished (issue #21).
+// The callback receives the realm name, encoded device ID, and the instant.
+type OnDeletionFunc func(realmName, deviceID string, at time.Time)
+
 // Service implements the Realm Management business logic over the store.
 type Service struct {
 	st   *store.Store
 	inv  Invalidator
 	disc Disconnecter
-	log  *slog.Logger
+	// OnDeletionStart / OnDeletionFinish bookend DeleteDevice (nil-safe).
+	OnDeletionStart  OnDeletionFunc
+	OnDeletionFinish OnDeletionFunc
+	log              *slog.Logger
 }
 
 // NewService builds the service. inv may be nil (e.g. management-only
@@ -72,7 +81,11 @@ func (s *Service) WithDisconnecter(d Disconnecter) *Service {
 // DeleteDevice synchronously removes a device and all its data (upstream
 // starts an async deletion with a transient deletion_in_progress state;
 // Astrate is single-process and deletes in one transaction —
-// docs/COMPATIBILITY.md).
+// docs/COMPATIBILITY.md). Emits device_deletion_started immediately before
+// the store delete and device_deletion_finished immediately after (issue
+// #21: back-to-back around the sync path so imported trigger configs still
+// fire). finished is emitted even when the store delete fails, so a started
+// lifecycle always closes.
 func (s *Service) DeleteDevice(ctx context.Context, realm, deviceID string) error {
 	rid, err := s.realmID(ctx, realm)
 	if err != nil {
@@ -85,7 +98,15 @@ func (s *Service) DeleteDevice(ctx context.Context, realm, deviceID string) erro
 	if s.disc != nil {
 		s.disc.DisconnectDevice(realm, id)
 	}
-	return s.st.DeleteDevice(ctx, rid, id)
+	at := time.Now().UTC()
+	if s.OnDeletionStart != nil {
+		s.OnDeletionStart(realm, deviceID, at)
+	}
+	err = s.st.DeleteDevice(ctx, rid, id)
+	if s.OnDeletionFinish != nil {
+		s.OnDeletionFinish(realm, deviceID, time.Now().UTC())
+	}
+	return err
 }
 
 // realmID resolves a realm name to its id; an unknown realm surfaces

--- a/internal/store/pipelines.go
+++ b/internal/store/pipelines.go
@@ -1,0 +1,190 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// ErrPipelineCyclic reports that a pipeline definition's block graph
+// contains a cycle.
+var ErrPipelineCyclic = errors.New("store: pipeline graph contains a cycle")
+
+// Pipeline is one stored Flow pipeline (astarte_flow parity, issue #24): a
+// named, realm-scoped DAG of blocks. Definition is the raw pipeline JSON
+// (internal/flow.Pipeline shape: "blocks" + "connections"); this package
+// does not import internal/flow (store imports none of its callers, see the
+// package doc), so the graph shape is decoded locally just far enough to
+// validate it.
+type Pipeline struct {
+	ID         int64
+	RealmID    int16
+	Name       string
+	Definition []byte
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+// pipelineGraph is the subset of internal/flow.Pipeline's JSON shape needed
+// to validate block references and acyclicity.
+type pipelineGraph struct {
+	Blocks []struct {
+		Name string `json:"name"`
+	} `json:"blocks"`
+	Connections []struct {
+		From string `json:"from"`
+		To   string `json:"to"`
+	} `json:"connections"`
+}
+
+// validatePipelineGraph checks that every connection references a declared
+// block and that the block graph is acyclic (Kahn's algorithm).
+func validatePipelineGraph(definition []byte) error {
+	var g pipelineGraph
+	if err := json.Unmarshal(definition, &g); err != nil {
+		return fmt.Errorf("store: pipeline definition does not parse: %w", err)
+	}
+	if len(g.Blocks) == 0 {
+		return fmt.Errorf("store: pipeline has no blocks")
+	}
+
+	names := make(map[string]bool, len(g.Blocks))
+	for _, b := range g.Blocks {
+		if b.Name == "" {
+			return fmt.Errorf("store: pipeline has a block with empty name")
+		}
+		names[b.Name] = true
+	}
+
+	inDeg := make(map[string]int, len(g.Blocks))
+	adj := make(map[string][]string, len(g.Blocks))
+	for _, c := range g.Connections {
+		if !names[c.From] || !names[c.To] {
+			return fmt.Errorf("store: pipeline connection references unknown block %q -> %q", c.From, c.To)
+		}
+		inDeg[c.To]++
+		adj[c.From] = append(adj[c.From], c.To)
+	}
+
+	var queue []string
+	for name := range names {
+		if inDeg[name] == 0 {
+			queue = append(queue, name)
+		}
+	}
+	visited := 0
+	for len(queue) > 0 {
+		n := queue[0]
+		queue = queue[1:]
+		visited++
+		for _, next := range adj[n] {
+			inDeg[next]--
+			if inDeg[next] == 0 {
+				queue = append(queue, next)
+			}
+		}
+	}
+	if visited != len(names) {
+		return ErrPipelineCyclic
+	}
+	return nil
+}
+
+// CreatePipeline validates and stores a pipeline; a duplicate name yields
+// ErrAlreadyExists, an invalid graph yields ErrPipelineCyclic or a plain
+// error for an unresolved block reference.
+func (s *Store) CreatePipeline(ctx context.Context, realmID int16, name string, definition []byte) (*Pipeline, error) {
+	if err := validatePipelineGraph(definition); err != nil {
+		return nil, err
+	}
+	p := Pipeline{RealmID: realmID, Name: name, Definition: definition}
+	err := s.pool.QueryRow(ctx,
+		`INSERT INTO pipelines (realm_id, name, definition) VALUES ($1, $2, $3)
+		 RETURNING id, created_at, updated_at`,
+		realmID, name, definition).Scan(&p.ID, &p.CreatedAt, &p.UpdatedAt)
+	if pgErrCode(err) == pgCodeUniqueViolation {
+		return nil, fmt.Errorf("%w: pipeline %q", ErrAlreadyExists, name)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("store: creating pipeline %q: %w", name, err)
+	}
+	return &p, nil
+}
+
+// GetPipeline fetches one pipeline by name.
+func (s *Store) GetPipeline(ctx context.Context, realmID int16, name string) (*Pipeline, error) {
+	var p Pipeline
+	err := s.pool.QueryRow(ctx,
+		`SELECT id, realm_id, name, definition, created_at, updated_at
+		 FROM pipelines WHERE realm_id = $1 AND name = $2`,
+		realmID, name).Scan(&p.ID, &p.RealmID, &p.Name, &p.Definition, &p.CreatedAt, &p.UpdatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("%w: pipeline %q", ErrNotFound, name)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("store: getting pipeline %q: %w", name, err)
+	}
+	return &p, nil
+}
+
+// UpdatePipeline validates and replaces a pipeline's definition.
+func (s *Store) UpdatePipeline(ctx context.Context, realmID int16, name string, definition []byte) (*Pipeline, error) {
+	if err := validatePipelineGraph(definition); err != nil {
+		return nil, err
+	}
+	var p Pipeline
+	err := s.pool.QueryRow(ctx,
+		`UPDATE pipelines SET definition = $3, updated_at = now()
+		 WHERE realm_id = $1 AND name = $2
+		 RETURNING id, realm_id, name, definition, created_at, updated_at`,
+		realmID, name, definition).Scan(&p.ID, &p.RealmID, &p.Name, &p.Definition, &p.CreatedAt, &p.UpdatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("%w: pipeline %q", ErrNotFound, name)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("store: updating pipeline %q: %w", name, err)
+	}
+	return &p, nil
+}
+
+// DeletePipeline removes a pipeline.
+func (s *Store) DeletePipeline(ctx context.Context, realmID int16, name string) error {
+	tag, err := s.pool.Exec(ctx,
+		`DELETE FROM pipelines WHERE realm_id = $1 AND name = $2`, realmID, name)
+	if err != nil {
+		return fmt.Errorf("store: deleting pipeline %q: %w", name, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("%w: pipeline %q", ErrNotFound, name)
+	}
+	return nil
+}
+
+// ListPipelines returns every pipeline of a realm ordered by name.
+func (s *Store) ListPipelines(ctx context.Context, realmID int16) ([]Pipeline, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT id, realm_id, name, definition, created_at, updated_at
+		 FROM pipelines WHERE realm_id = $1 ORDER BY name`,
+		realmID)
+	if err != nil {
+		return nil, fmt.Errorf("store: listing pipelines: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Pipeline
+	for rows.Next() {
+		var p Pipeline
+		if err := rows.Scan(&p.ID, &p.RealmID, &p.Name, &p.Definition, &p.CreatedAt, &p.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("store: scanning pipeline: %w", err)
+		}
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("store: listing pipelines: %w", err)
+	}
+	return out, nil
+}

--- a/internal/store/pipelines.go
+++ b/internal/store/pipelines.go
@@ -57,6 +57,9 @@ func validatePipelineGraph(definition []byte) error {
 		if b.Name == "" {
 			return fmt.Errorf("store: pipeline has a block with empty name")
 		}
+		if names[b.Name] {
+			return fmt.Errorf("store: pipeline has duplicate block name %q", b.Name)
+		}
 		names[b.Name] = true
 	}
 

--- a/internal/store/pipelines_test.go
+++ b/internal/store/pipelines_test.go
@@ -1,0 +1,76 @@
+//go:build integration
+
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func testPipelines(t *testing.T, s *Store) {
+	ctx := context.Background()
+	realm := mustCreateRealm(t, s)
+
+	def := []byte(`{"blocks":[{"name":"src"},{"name":"sink"}],"connections":[{"from":"src","to":"sink"}]}`)
+	p, err := s.CreatePipeline(ctx, realm.ID, "p1", def)
+	if err != nil {
+		t.Fatalf("CreatePipeline: %v", err)
+	}
+	if p.ID == 0 || p.Name != "p1" {
+		t.Errorf("created pipeline = %+v", p)
+	}
+	if _, err := s.CreatePipeline(ctx, realm.ID, "p1", def); !errors.Is(err, ErrAlreadyExists) {
+		t.Errorf("duplicate create = %v, want ErrAlreadyExists", err)
+	}
+
+	cyclic := []byte(`{"blocks":[{"name":"a"},{"name":"b"}],"connections":[{"from":"a","to":"b"},{"from":"b","to":"a"}]}`)
+	if _, err := s.CreatePipeline(ctx, realm.ID, "cyclic", cyclic); !errors.Is(err, ErrPipelineCyclic) {
+		t.Errorf("cyclic create = %v, want ErrPipelineCyclic", err)
+	}
+
+	if _, err := s.GetPipeline(ctx, realm.ID, "ghost"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("unknown get = %v, want ErrNotFound", err)
+	}
+	got, err := s.GetPipeline(ctx, realm.ID, "p1")
+	if err != nil {
+		t.Fatalf("GetPipeline: %v", err)
+	}
+	if got.RealmID != realm.ID {
+		t.Errorf("got.RealmID = %v, want %v", got.RealmID, realm.ID)
+	}
+
+	def2 := []byte(`{"blocks":[{"name":"src"},{"name":"mid"},{"name":"sink"}],"connections":[{"from":"src","to":"mid"},{"from":"mid","to":"sink"}]}`)
+	updated, err := s.UpdatePipeline(ctx, realm.ID, "p1", def2)
+	if err != nil {
+		t.Fatalf("UpdatePipeline: %v", err)
+	}
+	if !updated.UpdatedAt.After(p.CreatedAt) && !updated.UpdatedAt.Equal(p.CreatedAt) {
+		t.Errorf("UpdatedAt not advanced: created=%v updated=%v", p.CreatedAt, updated.UpdatedAt)
+	}
+	if _, err := s.UpdatePipeline(ctx, realm.ID, "ghost", def2); !errors.Is(err, ErrNotFound) {
+		t.Errorf("update unknown = %v, want ErrNotFound", err)
+	}
+
+	other := mustCreateRealm(t, s)
+	if _, err := s.CreatePipeline(ctx, other.ID, "elsewhere", def); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.CreatePipeline(ctx, realm.ID, "p2", def); err != nil {
+		t.Fatal(err)
+	}
+	list, err := s.ListPipelines(ctx, realm.ID)
+	if err != nil {
+		t.Fatalf("ListPipelines: %v", err)
+	}
+	if len(list) != 2 || list[0].Name != "p1" || list[1].Name != "p2" {
+		t.Errorf("list = %+v, want [p1 p2]", list)
+	}
+
+	if err := s.DeletePipeline(ctx, realm.ID, "p1"); err != nil {
+		t.Fatalf("DeletePipeline: %v", err)
+	}
+	if err := s.DeletePipeline(ctx, realm.ID, "p1"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("double delete = %v, want ErrNotFound", err)
+	}
+}

--- a/internal/store/pipelines_validate_test.go
+++ b/internal/store/pipelines_validate_test.go
@@ -1,0 +1,38 @@
+package store
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestValidatePipelineGraph_Acyclic(t *testing.T) {
+	def := []byte(`{
+		"blocks": [{"name": "a"}, {"name": "b"}, {"name": "c"}],
+		"connections": [{"from": "a", "to": "b"}, {"from": "b", "to": "c"}]
+	}`)
+	if err := validatePipelineGraph(def); err != nil {
+		t.Errorf("validatePipelineGraph(acyclic) = %v, want nil", err)
+	}
+}
+
+func TestValidatePipelineGraph_Cyclic(t *testing.T) {
+	def := []byte(`{
+		"blocks": [{"name": "a"}, {"name": "b"}, {"name": "c"}],
+		"connections": [{"from": "a", "to": "b"}, {"from": "b", "to": "c"}, {"from": "c", "to": "a"}]
+	}`)
+	err := validatePipelineGraph(def)
+	if !errors.Is(err, ErrPipelineCyclic) {
+		t.Errorf("validatePipelineGraph(cyclic) = %v, want ErrPipelineCyclic", err)
+	}
+}
+
+func TestValidatePipelineGraph_InvalidBlockRef(t *testing.T) {
+	def := []byte(`{
+		"blocks": [{"name": "a"}, {"name": "b"}],
+		"connections": [{"from": "a", "to": "ghost"}]
+	}`)
+	err := validatePipelineGraph(def)
+	if err == nil || errors.Is(err, ErrPipelineCyclic) {
+		t.Errorf("validatePipelineGraph(invalid ref) = %v, want a non-cyclic error", err)
+	}
+}

--- a/internal/store/pipelines_validate_test.go
+++ b/internal/store/pipelines_validate_test.go
@@ -36,3 +36,14 @@ func TestValidatePipelineGraph_InvalidBlockRef(t *testing.T) {
 		t.Errorf("validatePipelineGraph(invalid ref) = %v, want a non-cyclic error", err)
 	}
 }
+
+func TestValidatePipelineGraph_DuplicateBlockName(t *testing.T) {
+	def := []byte(`{
+		"blocks": [{"name": "a"}, {"name": "a"}],
+		"connections": []
+	}`)
+	err := validatePipelineGraph(def)
+	if err == nil || errors.Is(err, ErrPipelineCyclic) {
+		t.Errorf("validatePipelineGraph(duplicate name) = %v, want a non-cyclic error", err)
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -57,6 +57,7 @@ func TestStore(t *testing.T) {
 	t.Run("GroupsBatch", func(t *testing.T) { testGroupsBatch(t, s) })
 	t.Run("Triggers", func(t *testing.T) { testTriggers(t, s) })
 	t.Run("Policies", func(t *testing.T) { testPolicies(t, s) })
+	t.Run("Pipelines", func(t *testing.T) { testPipelines(t, s) })
 	t.Run("Notify", func(t *testing.T) { testNotify(t, s) })
 	t.Run("MigrationCycle", func(t *testing.T) { testMigrationCycle(t, s) })
 }
@@ -74,8 +75,8 @@ func testMigrations(t *testing.T, s *Store) {
 	if err := s.pool.QueryRow(ctx, `SELECT version, dirty FROM schema_migrations`).Scan(&version, &dirty); err != nil {
 		t.Fatalf("reading schema_migrations: %v", err)
 	}
-	if version != 7 || dirty {
-		t.Fatalf("schema_migrations: got version=%d dirty=%v, want version=7 dirty=false", version, dirty)
+	if version != 8 || dirty {
+		t.Fatalf("schema_migrations: got version=%d dirty=%v, want version=8 dirty=false", version, dirty)
 	}
 
 	hypertables := []string{"individual_datastreams", "object_datastreams"}
@@ -188,8 +189,8 @@ func testMigrationCycle(t *testing.T, s *Store) {
 	if err != nil {
 		t.Fatalf("reading version: %v", err)
 	}
-	if version != 7 || dirty {
-		t.Fatalf("after cycle: got version=%d dirty=%v, want version=7 dirty=false", version, dirty)
+	if version != 8 || dirty {
+		t.Fatalf("after cycle: got version=%d dirty=%v, want version=8 dirty=false", version, dirty)
 	}
 }
 

--- a/migrations/000008_pipelines.down.sql
+++ b/migrations/000008_pipelines.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS pipelines;

--- a/migrations/000008_pipelines.up.sql
+++ b/migrations/000008_pipelines.up.sql
@@ -1,0 +1,14 @@
+-- 000008: Flow pipeline storage (issue #24, astarte_flow parity). A pipeline
+-- is a JSON-serialisable DAG of named blocks (internal/flow.Pipeline shape);
+-- graph validity (acyclicity, block-reference resolution) is enforced by
+-- internal/store before the row is written, not by a DB constraint.
+
+CREATE TABLE pipelines (
+    id         bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    realm_id   smallint NOT NULL REFERENCES realms(id) ON DELETE CASCADE,
+    name       text NOT NULL,
+    definition jsonb NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (realm_id, name)
+);


### PR DESCRIPTION
## Summary

Unblocks five issues the mule could not finish on its own (never-touch `migrations/*` / `go.mod`, timeout on #27, plan-only "done" on #21). Work done on Mac so those constraints do not apply.

- **#14** — document + T1 test that `control/keyAgreement` is deliberately denied (upstream reserved, unimplemented)
- **#21** — emit `device_deletion_started` / `device_deletion_finished` around synchronous `DeleteDevice` (triggers + live bus + wiring)
- **#22** — render `template_type: "mustache"` HTTP action bodies via `github.com/cbroglie/mustache` (ROADMAP dep entry)
- **#24** — pipeline CRUD store, acyclic graph validation, migration `000008_pipelines`
- **#27** — `internal/flow/blocks/astartesource` Source block over `stream.Bus`

## Test plan

- [x] `go test ./internal/broker/ ./internal/engine/triggers/ ./internal/engine/ ./internal/flow/... ./pkg/...`
- [x] `go build ./cmd/astrate`
- [ ] `go test -tags integration ./internal/store/ ./internal/realm/` (pipeline CRUD + deletion lifecycle subtest)
- [ ] Review mule-review labels on #14 #21 #22 #24 #27 after merge, then close